### PR TITLE
Tombstones

### DIFF
--- a/packages/lib/src/data.ts
+++ b/packages/lib/src/data.ts
@@ -16,7 +16,7 @@ import {
 export const assureValidNextOp = async (
   did: string,
   ops: t.IndexedOperation[],
-  proposed: t.Operation,
+  proposed: t.OpOrTombstone,
 ): Promise<{ nullified: CID[]; prev: CID | null }> => {
   await assureValidOp(proposed)
 
@@ -80,15 +80,15 @@ export const assureValidNextOp = async (
 
 export const validateOperationLog = async (
   did: string,
-  ops: t.CompatibleOp[],
-): Promise<t.DocumentData> => {
+  ops: t.CompaitbleOpOrTombstone[],
+): Promise<t.DocumentData | null> => {
   // make sure they're all validly formatted operations
   const [first, ...rest] = ops
   if (!check.is(first, t.def.compatibleOp)) {
     throw new ImproperOperationError('incorrect structure', first)
   }
   for (const op of rest) {
-    if (!check.is(op, t.def.operation)) {
+    if (!check.is(op, t.def.opOrTombstone)) {
       throw new ImproperOperationError('incorrect structure', op)
     }
   }
@@ -97,12 +97,19 @@ export const validateOperationLog = async (
   let doc = await assureValidCreationOp(did, first)
   let prev = await cidForCbor(first)
 
-  for (const op of rest) {
+  for (let i = 0; i < rest.length; i++) {
+    const op = rest[i]
     if (!op.prev || !CID.parse(op.prev).equals(prev)) {
       throw new MisorderedOperationError()
     }
-
     await assureValidSig(doc.rotationKeys, op)
+    if (check.is(op, t.def.tombstone)) {
+      if (i === rest.length - 1) {
+        return null
+      } else {
+        throw new MisorderedOperationError()
+      }
+    }
     const { signingKey, rotationKeys, handles, services } = op
     doc = { did, signingKey, rotationKeys, handles, services }
     prev = await cidForCbor(op)

--- a/packages/lib/src/data.ts
+++ b/packages/lib/src/data.ts
@@ -43,6 +43,9 @@ export const assureValidNextOp = async (
   if (!lastOp) {
     throw new MisorderedOperationError()
   }
+  if (check.is(lastOp.operation, t.def.tombstone)) {
+    throw new MisorderedOperationError()
+  }
   const lastOpNormalized = normalizeOp(lastOp.operation)
   const firstNullified = nullified[0]
   // const firstNullifiedNormalized = normalizeCreateOp(firstNullified.operation)
@@ -80,7 +83,7 @@ export const assureValidNextOp = async (
 
 export const validateOperationLog = async (
   did: string,
-  ops: t.CompaitbleOpOrTombstone[],
+  ops: t.CompatibleOpOrTombstone[],
 ): Promise<t.DocumentData | null> => {
   // make sure they're all validly formatted operations
   const [first, ...rest] = ops
@@ -116,4 +119,15 @@ export const validateOperationLog = async (
   }
 
   return doc
+}
+
+export const getLastOpWithCid = async (
+  ops: t.CompatibleOpOrTombstone[],
+): Promise<{ op: t.CompatibleOpOrTombstone; cid: CID }> => {
+  const op = ops.at(-1)
+  if (!op) {
+    throw new Error('log is empty')
+  }
+  const cid = await cidForCbor(op)
+  return { op, cid }
 }

--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -1,8 +1,9 @@
 import * as cbor from '@ipld/dag-cbor'
+import { CID } from 'multiformats/cid'
 import * as uint8arrays from 'uint8arrays'
 import { Keypair, parseDidKey, sha256, verifySignature } from '@atproto/crypto'
-import * as t from './types'
 import { check } from '@atproto/common'
+import * as t from './types'
 import {
   GenesisHashError,
   ImproperlyFormattedDidError,
@@ -19,28 +20,43 @@ export const didForCreateOp = async (op: t.CompatibleOp, truncate = 24) => {
   return `did:plc:${truncated}`
 }
 
+export const addSignature = async <T extends Record<string, unknown>>(
+  object: T,
+  key: Keypair,
+): Promise<T & { sig: string }> => {
+  const data = new Uint8Array(cbor.encode(object))
+  const sig = await key.sign(data)
+  return {
+    ...object,
+    sig: uint8arrays.toString(sig, 'base64url'),
+  }
+}
+
 export const signOperation = async (
   op: t.UnsignedOperation,
   signingKey: Keypair,
 ): Promise<t.Operation> => {
-  const data = new Uint8Array(cbor.encode(op))
-  const sig = await signingKey.sign(data)
-  return {
-    ...op,
-    sig: uint8arrays.toString(sig, 'base64url'),
-  }
+  return addSignature(op, signingKey)
+}
+
+export const signTombstone = async (
+  prev: CID,
+  key: Keypair,
+): Promise<t.Tombstone> => {
+  return addSignature(
+    {
+      tombstone: true,
+      prev: prev.toString(),
+    },
+    key,
+  )
 }
 
 export const deprecatedSignCreate = async (
   op: t.UnsignedCreateOpV1,
   signingKey: Keypair,
 ): Promise<t.CreateOpV1> => {
-  const data = new Uint8Array(cbor.encode(op))
-  const sig = await signingKey.sign(data)
-  return {
-    ...op,
-    sig: uint8arrays.toString(sig, 'base64url'),
-  }
+  return addSignature(op, signingKey)
 }
 
 export const normalizeOp = (op: t.CompatibleOp): t.Operation => {
@@ -83,7 +99,7 @@ export const assureValidOp = async (op: t.OpOrTombstone) => {
 
 export const assureValidCreationOp = async (
   did: string,
-  op: t.CompaitbleOpOrTombstone,
+  op: t.CompatibleOpOrTombstone,
 ): Promise<t.DocumentData> => {
   if (check.is(op, t.def.tombstone)) {
     throw new MisorderedOperationError()
@@ -108,7 +124,7 @@ export const assureValidCreationOp = async (
 
 export const assureValidSig = async (
   allowedDids: string[],
-  op: t.CompaitbleOpOrTombstone,
+  op: t.CompatibleOpOrTombstone,
 ): Promise<string> => {
   const { sig, ...opData } = op
   const sigBytes = uint8arrays.fromString(sig, 'base64url')

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -57,11 +57,11 @@ export type OpOrTombstone = z.infer<typeof opOrTombstone>
 const compatibleOp = z.union([createOpV1, operation])
 export type CompatibleOp = z.infer<typeof compatibleOp>
 const compatibleOpOrTombstone = z.union([createOpV1, operation, tombstone])
-export type CompaitbleOpOrTombstone = z.infer<typeof compatibleOpOrTombstone>
+export type CompatibleOpOrTombstone = z.infer<typeof compatibleOpOrTombstone>
 
 export const indexedOperation = z.object({
   did: z.string(),
-  operation: compatibleOp,
+  operation: compatibleOpOrTombstone,
   cid: cid,
   nullified: z.boolean(),
   createdAt: z.date(),

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -44,8 +44,21 @@ export type UnsignedOperation = z.infer<typeof unsignedOperation>
 const operation = unsignedOperation.extend({ sig: z.string() })
 export type Operation = z.infer<typeof operation>
 
+const unsignedTombstone = z.object({
+  tombstone: z.literal(true),
+  prev: z.string(),
+})
+export type UnsignedTombstone = z.infer<typeof unsignedTombstone>
+const tombstone = unsignedTombstone.extend({ sig: z.string() })
+export type Tombstone = z.infer<typeof tombstone>
+
+const opOrTombstone = z.union([operation, tombstone])
+export type OpOrTombstone = z.infer<typeof opOrTombstone>
 const compatibleOp = z.union([createOpV1, operation])
 export type CompatibleOp = z.infer<typeof compatibleOp>
+const compatibleOpOrTombstone = z.union([createOpV1, operation, tombstone])
+export type CompaitbleOpOrTombstone = z.infer<typeof compatibleOpOrTombstone>
+
 export const indexedOperation = z.object({
   did: z.string(),
   operation: compatibleOp,
@@ -85,6 +98,9 @@ export const def = {
   createOpV1,
   unsignedOperation,
   operation,
+  tombstone,
+  opOrTombstone,
   compatibleOp,
+  compatibleOpOrTombstone,
   didDocument,
 }

--- a/packages/lib/tests/data.test.ts
+++ b/packages/lib/tests/data.test.ts
@@ -72,6 +72,9 @@ describe('plc did data', () => {
   it('parses an operation log with no updates', async () => {
     const doc = await data.validateOperationLog(did, ops)
 
+    if (!doc) {
+      throw new Error('expected doc')
+    }
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
@@ -85,6 +88,9 @@ describe('plc did data', () => {
     ops.push(op)
 
     const doc = await data.validateOperationLog(did, ops)
+    if (!doc) {
+      throw new Error('expected doc')
+    }
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
@@ -105,6 +111,9 @@ describe('plc did data', () => {
     ops.push(op)
 
     const doc = await data.validateOperationLog(did, ops)
+    if (!doc) {
+      throw new Error('expected doc')
+    }
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
@@ -125,6 +134,9 @@ describe('plc did data', () => {
     signingKey = newSigningKey
 
     const doc = await data.validateOperationLog(did, ops)
+    if (!doc) {
+      throw new Error('expected doc')
+    }
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
@@ -146,6 +158,10 @@ describe('plc did data', () => {
     rotationKey1 = newRotationKey
 
     const doc = await data.validateOperationLog(did, ops)
+    if (!doc) {
+      throw new Error('expected doc')
+    }
+
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
@@ -188,6 +204,9 @@ describe('plc did data', () => {
     ops.push(op)
     handle = newHandle
     const doc = await data.validateOperationLog(did, ops)
+    if (!doc) {
+      throw new Error('expected doc')
+    }
     expect(doc.did).toEqual(did)
     expect(doc.signingKey).toEqual(signingKey.did())
     expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -40,6 +40,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
       throw new ServerError(404, `DID not registered: ${did}`)
     }
     const data = await plc.validateOperationLog(did, log)
+    if (data === null) {
+      throw new ServerError(404, `DID not available: ${did}`)
+    }
     const doc = await plc.formatDidDoc(data)
     res.type('application/did+ld+json')
     res.send(JSON.stringify(doc))
@@ -53,6 +56,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
       throw new ServerError(404, `DID not registered: ${did}`)
     }
     const data = await plc.validateOperationLog(did, log)
+    if (data === null) {
+      throw new ServerError(404, `DID not available: ${did}`)
+    }
     res.json(data)
   })
 


### PR DESCRIPTION
Adds in tombstone operations.

These are recoverable operations just like any other.

They cause the did to 404 when requesting either the document or the data.

However, they still return operations in a full export or when requesting the ops of that particular record