### PR TITLE
Auditability

### DIFF
--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -24,7 +24,7 @@ export class Client {
 
   async getAuditableLog(did: string): Promise<t.ExportedOp[]> {
     const res = await axios.get(
-      `${this.url}/${encodeURIComponent(did)}/auditable`,
+      `${this.url}/${encodeURIComponent(did)}/log/audit`,
     )
     return res.data
   }
@@ -34,7 +34,9 @@ export class Client {
   }
 
   async getLastOp(did: string): Promise<t.CompatibleOpOrTombstone> {
-    const res = await axios.get(`${this.url}/${encodeURIComponent(did)}/last`)
+    const res = await axios.get(
+      `${this.url}/${encodeURIComponent(did)}/log/last`,
+    )
     return res.data
   }
 

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -17,16 +17,16 @@ export class Client {
     return res.data
   }
 
-  async getOperationLog(
-    did: string,
-    includeNull = false,
-  ): Promise<t.CompatibleOpOrTombstone[]> {
-    let url = `${this.url}/${encodeURIComponent(did)}/log`
-    if (includeNull) {
-      url += '?includeNull=true'
-    }
-    const res = await axios.get(url)
-    return res.data.log
+  async getOperationLog(did: string): Promise<t.CompatibleOpOrTombstone[]> {
+    const res = await axios.get(`${this.url}/${encodeURIComponent(did)}/log`)
+    return res.data
+  }
+
+  async getAuditableLog(did: string): Promise<t.ExportedOp[]> {
+    const res = await axios.get(
+      `${this.url}/${encodeURIComponent(did)}/auditable`,
+    )
+    return res.data
   }
 
   postOpUrl(did: string): string {
@@ -83,8 +83,15 @@ export class Client {
     await axios.post(this.postOpUrl(did), op)
   }
 
-  async export(): Promise<t.ExportedOp[]> {
-    const res = await axios.get(`${this.url}/export`)
+  async export(after?: string, count?: number): Promise<t.ExportedOp[]> {
+    const url = new URL(`${this.url}/export`)
+    if (after) {
+      url.searchParams.append('after', after)
+    }
+    if (count !== undefined) {
+      url.searchParams.append('count', count.toString(10))
+    }
+    const res = await axios.get(url.toString())
     const lines = res.data.split('\n')
     return lines.map((l) => JSON.parse(l))
   }

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -13,12 +13,19 @@ export class Client {
   }
 
   async getDocumentData(did: string): Promise<t.DocumentData> {
-    const res = await axios.get(`${this.url}/data/${encodeURIComponent(did)}`)
+    const res = await axios.get(`${this.url}/${encodeURIComponent(did)}/data`)
     return res.data
   }
 
-  async getOperationLog(did: string): Promise<t.Operation[]> {
-    const res = await axios.get(`${this.url}/log/${encodeURIComponent(did)}`)
+  async getOperationLog(
+    did: string,
+    includeNull = false,
+  ): Promise<t.Operation[]> {
+    let url = `${this.url}/${encodeURIComponent(did)}/log`
+    if (includeNull) {
+      url += '?includeNull=true'
+    }
+    const res = await axios.get(url)
     return res.data.log
   }
 
@@ -27,7 +34,7 @@ export class Client {
   }
 
   async getLastOp(did: string): Promise<t.Operation> {
-    const res = await axios.get(`${this.url}/last/${encodeURIComponent(did)}`)
+    const res = await axios.get(`${this.url}/${encodeURIComponent(did)}/last`)
     return res.data
   }
 

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -68,6 +68,14 @@ export const indexedOperation = z.object({
 })
 export type IndexedOperation = z.infer<typeof indexedOperation>
 
+export type ExportedOp = {
+  did: string
+  operation: CompatibleOpOrTombstone
+  cid: string
+  nullified: boolean
+  createdAt: Date
+}
+
 export const didDocVerificationMethod = z.object({
   id: z.string(),
   type: z.string(),

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -68,13 +68,14 @@ export const indexedOperation = z.object({
 })
 export type IndexedOperation = z.infer<typeof indexedOperation>
 
-export type ExportedOp = {
-  did: string
-  operation: CompatibleOpOrTombstone
-  cid: string
-  nullified: boolean
-  createdAt: Date
-}
+export const exportedOp = z.object({
+  did: z.string(),
+  operation: compatibleOpOrTombstone,
+  cid: z.string(),
+  nullified: z.boolean(),
+  createdAt: z.string(),
+})
+export type ExportedOp = z.infer<typeof exportedOp>
 
 export const didDocVerificationMethod = z.object({
   id: z.string(),
@@ -110,5 +111,7 @@ export const def = {
   opOrTombstone,
   compatibleOp,
   compatibleOpOrTombstone,
+  indexedOperation,
+  exportedOp,
   didDocument,
 }

--- a/packages/lib/tests/compatibility.test.ts
+++ b/packages/lib/tests/compatibility.test.ts
@@ -78,6 +78,6 @@ describe('compatibility', () => {
 
     const result = await assureValidNextOp(did, [indexedLegacy], nextOp)
     expect(result.nullified.length).toBe(0)
-    expect(result.prev?.equals(legacyCid))
+    expect(result.prev?.equals(legacyCid)).toBeTruthy()
   })
 })

--- a/packages/lib/tests/recovery.test.ts
+++ b/packages/lib/tests/recovery.test.ts
@@ -106,7 +106,7 @@ describe('plc recovery', () => {
     expect(res.nullified.length).toBe(2)
     expect(res.nullified[0].equals(log[1].cid))
     expect(res.nullified[1].equals(log[2].cid))
-    expect(res.prev?.equals(createCid))
+    expect(res.prev?.equals(createCid)).toBeTruthy()
 
     log = [log[0], rotate.indexed]
   })
@@ -124,7 +124,7 @@ describe('plc recovery', () => {
     const res = await data.assureValidNextOp(did, log, rotate.op)
     expect(res.nullified.length).toBe(1)
     expect(res.nullified[0].equals(log[1].cid))
-    expect(res.prev?.equals(createCid))
+    expect(res.prev?.equals(createCid)).toBeTruthy()
 
     log = [log[0], rotate.indexed]
   })
@@ -185,6 +185,6 @@ describe('plc recovery', () => {
     )
     expect(result.nullified.length).toBe(1)
     expect(result.nullified[0].equals(cid))
-    expect(result.prev?.equals(createCid))
+    expect(result.prev?.equals(createCid)).toBeTruthy()
   })
 })

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -201,12 +201,16 @@ export class Database implements PlcDatabase {
     let builder = this.db
       .selectFrom('operations')
       .selectAll()
-      .orderBy('createdAt', 'desc')
+      .orderBy('createdAt', 'asc')
       .limit(count)
     if (after) {
       builder = builder.where('createdAt', '>', after)
     }
-    return builder.execute()
+    const res = await builder.execute()
+    return res.map((row) => ({
+      ...row,
+      createdAt: row.createdAt.toISOString(),
+    }))
   }
 }
 

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,11 +1,11 @@
-import { Kysely, Migrator, PostgresDialect, Selectable, sql } from 'kysely'
+import { Kysely, Migrator, PostgresDialect, sql } from 'kysely'
 import { Pool as PgPool, types as pgTypes } from 'pg'
 import { CID } from 'multiformats/cid'
 import { cidForCbor } from '@atproto/common'
 import * as plc from '@did-plc/lib'
 import { ServerError } from '../error'
 import * as migrations from '../migrations'
-import { DatabaseSchema, OperationsTable, PlcDatabase } from './types'
+import { DatabaseSchema, PlcDatabase } from './types'
 import MockDatabase from './mock'
 
 export * from './mock'
@@ -197,10 +197,7 @@ export class Database implements PlcDatabase {
     return res?.operation ?? null
   }
 
-  async exportOps(
-    count: number,
-    after?: Date,
-  ): Promise<Selectable<OperationsTable>[]> {
+  async exportOps(count: number, after?: Date): Promise<plc.ExportedOp[]> {
     let builder = this.db
       .selectFrom('operations')
       .selectAll()

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,11 +1,11 @@
-import { Generated, Kysely, Migrator, PostgresDialect, sql } from 'kysely'
+import { Kysely, Migrator, PostgresDialect, Selectable, sql } from 'kysely'
 import { Pool as PgPool, types as pgTypes } from 'pg'
 import { CID } from 'multiformats/cid'
-import { cidForCbor, check } from '@atproto/common'
+import { cidForCbor } from '@atproto/common'
 import * as plc from '@did-plc/lib'
 import { ServerError } from '../error'
 import * as migrations from '../migrations'
-import { OpLogExport, PlcDatabase } from './types'
+import { DatabaseSchema, OperationsTable, PlcDatabase } from './types'
 import MockDatabase from './mock'
 
 export * from './mock'
@@ -93,7 +93,7 @@ export class Database implements PlcDatabase {
   }
 
   async validateAndAddOp(did: string, proposed: plc.Operation): Promise<void> {
-    const ops = await this._opsForDid(did)
+    const ops = await this.indexedOpsForDid(did)
     // throws if invalid
     const { nullified, prev } = await plc.assureValidNextOp(did, ops, proposed)
     const cid = await cidForCbor(proposed)
@@ -158,25 +158,24 @@ export class Database implements PlcDatabase {
     return found ? CID.parse(found.cid) : null
   }
 
-  async opsForDid(did: string): Promise<plc.OpOrTombstone[]> {
-    const ops = await this._opsForDid(did)
-    return ops.map((op) => {
-      if (check.is(op.operation, plc.def.createOpV1)) {
-        return plc.normalizeOp(op.operation)
-      }
-      return op.operation
-    })
+  async opsForDid(did: string): Promise<plc.CompatibleOpOrTombstone[]> {
+    const ops = await this.indexedOpsForDid(did)
+    return ops.map((op) => op.operation)
   }
 
-  async _opsForDid(did: string): Promise<plc.IndexedOperation[]> {
-    const res = await this.db
+  async indexedOpsForDid(
+    did: string,
+    includeNullified = false,
+  ): Promise<plc.IndexedOperation[]> {
+    let builder = this.db
       .selectFrom('operations')
       .selectAll()
       .where('did', '=', did)
-      .where('nullified', '=', false)
       .orderBy('createdAt', 'asc')
-      .execute()
-
+    if (!includeNullified) {
+      builder = builder.where('nullified', '=', false)
+    }
+    const res = await builder.execute()
     return res.map((row) => ({
       did: row.did,
       operation: row.operation,
@@ -186,36 +185,32 @@ export class Database implements PlcDatabase {
     }))
   }
 
-  async fullExport(): Promise<Record<string, OpLogExport>> {
-    return {}
-    //   const res = await this.db
-    //     .selectFrom('operations')
-    //     .selectAll()
-    //     .orderBy('did')
-    //     .orderBy('createdAt')
-    //     .execute()
-    //   return res.reduce((acc, cur) => {
-    //     acc[cur.did] ??= []
-    //     acc[cur.did].push({
-    //       op: cur.operation),
-    //       nullified: cur.nullified === 1,
-    //       createdAt: cur.createdAt,
-    //     })
-    //     return acc
-    //   }, {} as Record<string, OpLogExport>)
+  async lastOpForDid(did: string): Promise<plc.CompatibleOpOrTombstone | null> {
+    const res = await this.db
+      .selectFrom('operations')
+      .selectAll()
+      .where('did', '=', did)
+      .where('nullified', '=', false)
+      .orderBy('createdAt', 'desc')
+      .limit(1)
+      .executeTakeFirst()
+    return res?.operation ?? null
+  }
+
+  async exportOps(
+    count: number,
+    after?: Date,
+  ): Promise<Selectable<OperationsTable>[]> {
+    let builder = this.db
+      .selectFrom('operations')
+      .selectAll()
+      .orderBy('createdAt', 'desc')
+      .limit(count)
+    if (after) {
+      builder = builder.where('createdAt', '>', after)
+    }
+    return builder.execute()
   }
 }
 
 export default Database
-
-interface OperationsTable {
-  did: string
-  operation: plc.CompatibleOpOrTombstone
-  cid: string
-  nullified: boolean
-  createdAt: Generated<Date>
-}
-
-interface DatabaseSchema {
-  operations: OperationsTable
-}

--- a/packages/server/src/db/mock.ts
+++ b/packages/server/src/db/mock.ts
@@ -1,8 +1,7 @@
 import { cidForCbor, check } from '@atproto/common'
 import * as plc from '@did-plc/lib'
-import { Selectable } from 'kysely'
 import { ServerError } from '../error'
-import { OperationsTable, PlcDatabase } from './types'
+import { PlcDatabase } from './types'
 
 type Contents = Record<string, plc.IndexedOperation[]>
 
@@ -73,10 +72,7 @@ export class MockDatabase implements PlcDatabase {
   }
 
   // disabled in mocks
-  async exportOps(
-    _count: number,
-    _after?: Date,
-  ): Promise<Selectable<OperationsTable>[]> {
+  async exportOps(_count: number, _after?: Date): Promise<plc.ExportedOp[]> {
     return []
   }
 }

--- a/packages/server/src/db/types.ts
+++ b/packages/server/src/db/types.ts
@@ -1,5 +1,5 @@
 import * as plc from '@did-plc/lib'
-import { Generated, Selectable } from 'kysely'
+import { Generated } from 'kysely'
 
 export interface PlcDatabase {
   close(): Promise<void>
@@ -11,7 +11,7 @@ export interface PlcDatabase {
     includeNull?: boolean,
   ): Promise<plc.IndexedOperation[]>
   lastOpForDid(did: string): Promise<plc.CompatibleOpOrTombstone | null>
-  exportOps(count: number, after?: Date): Promise<Selectable<OperationsTable>[]>
+  exportOps(count: number, after?: Date): Promise<plc.ExportedOp[]>
 }
 
 export interface OperationsTable {

--- a/packages/server/src/db/types.ts
+++ b/packages/server/src/db/types.ts
@@ -1,18 +1,27 @@
 import * as plc from '@did-plc/lib'
+import { Generated, Selectable } from 'kysely'
 
 export interface PlcDatabase {
   close(): Promise<void>
   healthCheck(): Promise<void>
   validateAndAddOp(did: string, proposed: plc.Operation): Promise<void>
-  opsForDid(did: string): Promise<plc.OpOrTombstone[]>
-  _opsForDid(did: string): Promise<plc.IndexedOperation[]>
-  fullExport(): Promise<Record<string, OpLogExport>>
+  opsForDid(did: string): Promise<plc.CompatibleOpOrTombstone[]>
+  indexedOpsForDid(
+    did: string,
+    includeNull?: boolean,
+  ): Promise<plc.IndexedOperation[]>
+  lastOpForDid(did: string): Promise<plc.CompatibleOpOrTombstone | null>
+  exportOps(count: number, after?: Date): Promise<Selectable<OperationsTable>[]>
 }
 
-export type OpLogExport = OpExport[]
-
-export type OpExport = {
-  op: Record<string, unknown>
+export interface OperationsTable {
+  did: string
+  operation: plc.CompatibleOpOrTombstone
+  cid: string
   nullified: boolean
-  createdAt: string
+  createdAt: Generated<Date>
+}
+
+export interface DatabaseSchema {
+  operations: OperationsTable
 }

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -20,8 +20,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
 
   // Export ops in the form of paginated json lines
   router.get('/export', async function (req, res) {
-    const { count } = req.query
-    const parsedCount = count ? parseInt(count, 10) : 1000
+    const parsedCount = req.count ? parseInt(req.count, 10) : 1000
     if (isNaN(parsedCount) || parsedCount < 1) {
       throw new ServerError(400, 'Invalid count parameter')
     }
@@ -81,7 +80,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get operation log for a DID
-  router.get('/:did/auditable', async function (req, res) {
+  router.get('/:did/log/audit', async function (req, res) {
     const { did } = req.params
     const ops = await ctx.db.indexedOpsForDid(did, true)
     if (ops.length === 0) {
@@ -97,7 +96,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   // Get the most recent operation in the log for a DID
-  router.get('/:did/last', async function (req, res) {
+  router.get('/:did/log/last', async function (req, res) {
     const { did } = req.params
     const last = await ctx.db.lastOpForDid(did)
     if (!last) {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -20,8 +20,12 @@ export const createRouter = (ctx: AppContext): express.Router => {
 
   // Export ops in the form of paginated json lines
   router.get('/export', async function (req, res) {
-    const parsedCount = parseInt(req.query.count)
-    const count = isNaN(parsedCount) ? 1000 : Math.min(parsedCount, 1000)
+    const { count } = req.query
+    const parsedCount = count ? parseInt(count, 10) : 1000
+    if (isNaN(parsedCount) || parsedCount < 1) {
+      throw new ServerError(400, 'Invalid count parameter')
+    }
+    const count = Math.min(parsedCount, 1000)
     const after = req.query.after ? new Date(req.query.after) : undefined
     const ops = await ctx.db.exportOps(count, after)
     res.setHeader('content-type', 'application/jsonlines')

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -26,10 +26,12 @@ export const createRouter = (ctx: AppContext): express.Router => {
     const ops = await ctx.db.exportOps(count, after)
     res.setHeader('content-type', 'application/jsonlines')
     res.status(200)
-    for (const op of ops) {
-      const line = JSON.stringify(op)
+    for (let i = 0; i < ops.length; i++) {
+      if (i > 0) {
+        res.write('\n')
+      }
+      const line = JSON.stringify(ops[i])
       res.write(line)
-      res.write('\n')
     }
     res.end()
   })

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -1,7 +1,7 @@
 import { EcdsaKeypair } from '@atproto/crypto'
 import * as plc from '@did-plc/lib'
 import { CloseFn, runTestServer } from './_util'
-import { cidForCbor } from '@atproto/common'
+import { check, cidForCbor } from '@atproto/common'
 import { AxiosError } from 'axios'
 import { Database } from '../src'
 import { signOperation } from '@did-plc/lib'
@@ -133,7 +133,7 @@ describe('PLC server', () => {
     const newKey = await EcdsaKeypair.create()
     const ops = await client.getOperationLog(did)
     const forkPoint = ops.at(-2)
-    if (!forkPoint) {
+    if (!check.is(forkPoint, plc.def.operation)) {
       throw new Error('Could not find fork point')
     }
     const forkCid = await cidForCbor(forkPoint)
@@ -217,6 +217,10 @@ describe('PLC server', () => {
 
     const ops = await client.getOperationLog(did)
     await plc.validateOperationLog(did, ops)
+  })
+
+  it('exports the data set', async () => {
+    await client.export()
   })
 
   it('healthcheck succeeds when database is available.', async () => {


### PR DESCRIPTION
Adds two new routes
- `/export` which exports the _entire_ PLC database as a series of jsonlines, where each line is an operation ordered by `createdAt` time. This is paginated with a limit of 1000 lines per req
- `/:did/auditable` which gives the auditable log for a user that includes timestamps & nullified operations