### PR TITLE
Mirror did doc semantics

### DIFF
--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -1,8 +1,15 @@
-import { check, cidForCbor } from '@atproto/common'
+import { check } from '@atproto/common'
 import { Keypair } from '@atproto/crypto'
 import axios from 'axios'
-import { CID } from 'multiformats/cid'
-import { didForCreateOp, normalizeOp, signOperation } from './operations'
+import {
+  atprotoOp,
+  createUpdateOp,
+  didForCreateOp,
+  updateAtprotoKeyOp,
+  updateHandleOp,
+  updatePdsOp,
+  updateRotationKeysOp,
+} from './operations'
 import * as t from './types'
 
 export class Client {
@@ -39,54 +46,6 @@ export class Client {
     return res.data
   }
 
-  async updateData(
-    did: string,
-    key: Keypair,
-    fn: (lastOp: t.Operation, prev: CID) => Promise<t.UnsignedOperation>,
-  ) {
-    const lastOp = await this.getLastOp(did)
-    if (check.is(lastOp, t.def.tombstone)) {
-      throw new Error('Cannot apply op to tombstone')
-    }
-    const normalized = normalizeOp(lastOp)
-    const prev = await cidForCbor(lastOp)
-    const unsigned = await fn(normalized, prev)
-    const op = await signOperation(unsigned, key)
-    await this.sendOperation(did, op)
-  }
-
-  async applyPartialOp(
-    did: string,
-    delta: Partial<t.UnsignedOperation>,
-    key: Keypair,
-  ) {
-    await this.updateData(did, key, async (lastOp, prev) => ({
-      type: 'plc_operation',
-      verificationMethods: lastOp.verificationMethods,
-      rotationKeys: lastOp.rotationKeys,
-      alsoKnownAs: lastOp.alsoKnownAs,
-      services: lastOp.services,
-      prev: prev.toString(),
-      ...delta,
-    }))
-  }
-
-  async create(
-    op: Omit<t.UnsignedOperation, 'prev'>,
-    key: Keypair,
-  ): Promise<string> {
-    const createOp = await signOperation(
-      {
-        ...op,
-        prev: null,
-      },
-      key,
-    )
-    const did = await didForCreateOp(createOp)
-    await this.sendOperation(did, createOp)
-    return did
-  }
-
   async sendOperation(did: string, op: t.OpOrTombstone) {
     await axios.post(this.postOpUrl(did), op)
   }
@@ -102,6 +61,61 @@ export class Client {
     const res = await axios.get(url.toString())
     const lines = res.data.split('\n')
     return lines.map((l) => JSON.parse(l))
+  }
+
+  async createDid(opts: {
+    signingKey: string
+    handle: string
+    pds: string
+    rotationKeys: string[]
+    signer: Keypair
+  }): Promise<string> {
+    const op = await atprotoOp({ ...opts, prev: null })
+    const did = await didForCreateOp(op)
+    await this.sendOperation(did, op)
+    return did
+  }
+
+  private async ensureLastOp(did) {
+    const lastOp = await this.getLastOp(did)
+    if (check.is(lastOp, t.def.tombstone)) {
+      throw new Error('Cannot apply op to tombstone')
+    }
+    return lastOp
+  }
+
+  async updateData(
+    did: string,
+    signer: Keypair,
+    fn: (lastOp: t.UnsignedOperation) => Omit<t.UnsignedOperation, 'prev'>,
+  ) {
+    const lastOp = await this.ensureLastOp(did)
+    const op = await createUpdateOp(lastOp, signer, fn)
+    await this.sendOperation(did, op)
+  }
+
+  async updateAtprotoKey(did: string, signer: Keypair, atprotoKey: string) {
+    const lastOp = await this.ensureLastOp(did)
+    const op = await updateAtprotoKeyOp(lastOp, signer, atprotoKey)
+    await this.sendOperation(did, op)
+  }
+
+  async updateHandle(did: string, signer: Keypair, handle: string) {
+    const lastOp = await this.ensureLastOp(did)
+    const op = await updateHandleOp(lastOp, signer, handle)
+    await this.sendOperation(did, op)
+  }
+
+  async updatePds(did: string, signer: Keypair, endpoint: string) {
+    const lastOp = await this.ensureLastOp(did)
+    const op = await updatePdsOp(lastOp, signer, endpoint)
+    await this.sendOperation(did, op)
+  }
+
+  async updateRotationKeys(did: string, signer: Keypair, keys: string[]) {
+    const lastOp = await this.ensureLastOp(did)
+    const op = await updateRotationKeysOp(lastOp, signer, keys)
+    await this.sendOperation(did, op)
   }
 
   async health() {

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -1,10 +1,11 @@
-import { check } from '@atproto/common'
+import { check, cidForCbor } from '@atproto/common'
 import { Keypair } from '@atproto/crypto'
 import axios from 'axios'
 import {
   atprotoOp,
   createUpdateOp,
   didForCreateOp,
+  tombstoneOp,
   updateAtprotoKeyOp,
   updateHandleOp,
   updatePdsOp,
@@ -115,6 +116,13 @@ export class Client {
   async updateRotationKeys(did: string, signer: Keypair, keys: string[]) {
     const lastOp = await this.ensureLastOp(did)
     const op = await updateRotationKeysOp(lastOp, signer, keys)
+    await this.sendOperation(did, op)
+  }
+
+  async tombstone(did: string, signer: Keypair) {
+    const lastOp = await this.ensureLastOp(did)
+    const prev = await cidForCbor(lastOp)
+    const op = await tombstoneOp(prev, signer)
     await this.sendOperation(did, op)
   }
 

--- a/packages/lib/src/data.ts
+++ b/packages/lib/src/data.ts
@@ -113,8 +113,8 @@ export const validateOperationLog = async (
         throw new MisorderedOperationError()
       }
     }
-    const { signingKey, rotationKeys, handles, services } = op
-    doc = { did, signingKey, rotationKeys, handles, services }
+    const { verificationMethods, rotationKeys, alsoKnownAs, services } = op
+    doc = { did, verificationMethods, rotationKeys, alsoKnownAs, services }
     prev = await cidForCbor(op)
   }
 

--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -20,17 +20,8 @@ export const didForCreateOp = async (op: t.CompatibleOp, truncate = 24) => {
   return `did:plc:${truncated}`
 }
 
-export const addSignature = async <T extends Record<string, unknown>>(
-  object: T,
-  key: Keypair,
-): Promise<T & { sig: string }> => {
-  const data = new Uint8Array(cbor.encode(object))
-  const sig = await key.sign(data)
-  return {
-    ...object,
-    sig: uint8arrays.toString(sig, 'base64url'),
-  }
-}
+// Operations formatting
+// ---------------------------
 
 export const formatAtprotoOp = (opts: {
   signingKey: string
@@ -159,14 +150,7 @@ export const updateRotationKeysOp = async (
   })
 }
 
-export const signOperation = async (
-  op: t.UnsignedOperation,
-  signingKey: Keypair,
-): Promise<t.Operation> => {
-  return addSignature(op, signingKey)
-}
-
-export const signTombstone = async (
+export const tombstoneOp = async (
   prev: CID,
   key: Keypair,
 ): Promise<t.Tombstone> => {
@@ -178,6 +162,31 @@ export const signTombstone = async (
     key,
   )
 }
+
+// Signing operations
+// ---------------------------
+
+export const addSignature = async <T extends Record<string, unknown>>(
+  object: T,
+  key: Keypair,
+): Promise<T & { sig: string }> => {
+  const data = new Uint8Array(cbor.encode(object))
+  const sig = await key.sign(data)
+  return {
+    ...object,
+    sig: uint8arrays.toString(sig, 'base64url'),
+  }
+}
+
+export const signOperation = async (
+  op: t.UnsignedOperation,
+  signingKey: Keypair,
+): Promise<t.Operation> => {
+  return addSignature(op, signingKey)
+}
+
+// Backwards compatibility
+// ---------------------------
 
 export const deprecatedSignCreate = async (
   op: t.UnsignedCreateOpV1,
@@ -207,6 +216,9 @@ export const normalizeOp = (op: t.CompatibleOp): t.Operation => {
     sig: op.sig,
   }
 }
+
+// Verifying operations/signatures
+// ---------------------------
 
 export const assureValidOp = async (op: t.OpOrTombstone) => {
   if (check.is(op, t.def.tombstone)) {
@@ -272,6 +284,9 @@ export const assureValidSig = async (
   }
   throw new InvalidSignatureError(op)
 }
+
+// Util
+// ---------------------------
 
 export const ensureHttpPrefix = (str: string): string => {
   if (str.startsWith('http://') || str.startsWith('https://')) {

--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -70,15 +70,12 @@ export const atprotoOp = async (opts: {
 export const createUpdateOp = async (
   lastOp: t.CompatibleOp,
   signer: Keypair,
-  fn: (
-    normalized: t.UnsignedOperation,
-    prev: CID,
-  ) => Omit<t.UnsignedOperation, 'prev'>,
+  fn: (normalized: t.UnsignedOperation) => Omit<t.UnsignedOperation, 'prev'>,
 ): Promise<t.Operation> => {
   const prev = await cidForCbor(lastOp)
   // omit sig so it doesn't accidentally make its way into the next operation
   const { sig, ...normalized } = normalizeOp(lastOp)
-  const unsigned = await fn(normalized, prev)
+  const unsigned = await fn(normalized)
   return addSignature(
     {
       ...unsigned,
@@ -149,7 +146,7 @@ export const updatePdsOp = async (
   })
 }
 
-export const updateRotationkeysOp = async (
+export const updateRotationKeysOp = async (
   lastOp: t.CompatibleOp,
   signer: Keypair,
   rotationKeys: string[],

--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -58,6 +58,18 @@ export const atprotoOp = async (opts: {
   return addSignature(formatAtprotoOp(opts), opts.signer)
 }
 
+export const createOp = async (opts: {
+  signingKey: string
+  handle: string
+  pds: string
+  rotationKeys: string[]
+  signer: Keypair
+}): Promise<{ op: t.Operation; did: string }> => {
+  const op = await atprotoOp({ ...opts, prev: null })
+  const did = await didForCreateOp(op)
+  return { op, did }
+}
+
 export const createUpdateOp = async (
   lastOp: t.CompatibleOp,
   signer: Keypair,

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -8,14 +8,17 @@ const cid = z
   })
   .transform((obj: unknown) => mf.CID.asCID(obj) as mf.CID)
 
+const service = z.object({
+  type: z.string(),
+  endpoint: z.string(),
+})
+
 const documentData = z.object({
   did: z.string(),
-  signingKey: z.string(),
   rotationKeys: z.array(z.string()),
-  handles: z.array(z.string()),
-  services: z.object({
-    atpPds: z.string().optional(),
-  }),
+  verificationMethods: z.record(z.string()),
+  alsoKnownAs: z.array(z.string()),
+  services: z.record(service),
 })
 export type DocumentData = z.infer<typeof documentData>
 
@@ -32,12 +35,11 @@ const createOpV1 = unsignedCreateOpV1.extend({ sig: z.string() })
 export type CreateOpV1 = z.infer<typeof createOpV1>
 
 const unsignedOperation = z.object({
-  signingKey: z.string(),
+  type: z.literal('plc_operation'),
   rotationKeys: z.array(z.string()),
-  handles: z.array(z.string()),
-  services: z.object({
-    atpPds: z.string().optional(),
-  }),
+  verificationMethods: z.record(z.string()),
+  alsoKnownAs: z.array(z.string()),
+  services: z.record(service),
   prev: z.string().nullable(),
 })
 export type UnsignedOperation = z.infer<typeof unsignedOperation>
@@ -45,7 +47,7 @@ const operation = unsignedOperation.extend({ sig: z.string() })
 export type Operation = z.infer<typeof operation>
 
 const unsignedTombstone = z.object({
-  tombstone: z.literal(true),
+  type: z.literal('plc_tombstone'),
   prev: z.string(),
 })
 export type UnsignedTombstone = z.infer<typeof unsignedTombstone>
@@ -95,9 +97,6 @@ export const didDocument = z.object({
   id: z.string(),
   alsoKnownAs: z.array(z.string()),
   verificationMethod: z.array(didDocVerificationMethod),
-  assertionMethod: z.array(z.string()),
-  capabilityInvocation: z.array(z.string()),
-  capabilityDelegation: z.array(z.string()),
   service: z.array(didDocService),
 })
 export type DidDocument = z.infer<typeof didDocument>

--- a/packages/lib/tests/compatibility.test.ts
+++ b/packages/lib/tests/compatibility.test.ts
@@ -6,7 +6,8 @@ import {
   deprecatedSignCreate,
   didForCreateOp,
   normalizeOp,
-  signOperation,
+  updateRotationkeysOp,
+  updateAtprotoKeyOp,
   validateOperationLog,
 } from '../src'
 
@@ -41,11 +42,17 @@ describe('compatibility', () => {
 
     const normalized = normalizeOp(legacyOp)
     expect(normalized).toEqual({
-      signingKey: signingKey.did(),
+      type: 'plc_operation',
+      verificationMethods: {
+        atproto: signingKey.did(),
+      },
       rotationKeys: [recoveryKey.did(), signingKey.did()],
-      handles: [handle],
+      alsoKnownAs: [`at://${handle}`],
       services: {
-        atpPds: service,
+        atproto_pds: {
+          type: 'AtprotoPersonalDataServer',
+          endpoint: service,
+        },
       },
       prev: null,
       sig: legacyOp.sig,
@@ -56,18 +63,35 @@ describe('compatibility', () => {
     const legacyCid = await cidForCbor(legacyOp)
     const newSigner = await Secp256k1Keypair.create()
     const newRotater = await Secp256k1Keypair.create()
-    const nextOp = await signOperation(
-      {
-        signingKey: newSigner.did(),
-        rotationKeys: [newRotater.did()],
-        handles: [handle],
-        services: { atpPds: service },
-        prev: legacyCid.toString(),
-      },
+    const nextOp = await updateAtprotoKeyOp(
+      legacyOp,
       signingKey,
+      newSigner.did(),
     )
+    const anotherOp = await updateRotationkeysOp(nextOp, signingKey, [
+      newRotater.did(),
+    ])
+    //   {
+    //     type: 'plc_operation',
+    //     verificationMethods: {
+    //       atproto: newSigner.did(),
+    //     },
+    //     rotationKeys: [newRotater.did()],
+    //     alsoKnownAs: [`at://${handle}`],
+    //     services: {
+    //       atproto_pds: {
+    //         type: 'AtprotoPersonalDataServer',
+    //         endpoint: service,
+    //       },
+    //     },
+    //     prev: legacyCid.toString(),
+    //   },
+    //   signingKey,
+    // )
     await validateOperationLog(did, [legacyOp, nextOp])
+    // await validateOperationLog(did, [legacyOp, nextOp, anotherOp])
 
+    return
     const indexedLegacy = {
       did,
       operation: legacyOp,

--- a/packages/lib/tests/compatibility.test.ts
+++ b/packages/lib/tests/compatibility.test.ts
@@ -6,7 +6,7 @@ import {
   deprecatedSignCreate,
   didForCreateOp,
   normalizeOp,
-  updateRotationkeysOp,
+  updateRotationKeysOp,
   updateAtprotoKeyOp,
   validateOperationLog,
 } from '../src'
@@ -68,30 +68,12 @@ describe('compatibility', () => {
       signingKey,
       newSigner.did(),
     )
-    const anotherOp = await updateRotationkeysOp(nextOp, signingKey, [
+    const anotherOp = await updateRotationKeysOp(nextOp, signingKey, [
       newRotater.did(),
     ])
-    //   {
-    //     type: 'plc_operation',
-    //     verificationMethods: {
-    //       atproto: newSigner.did(),
-    //     },
-    //     rotationKeys: [newRotater.did()],
-    //     alsoKnownAs: [`at://${handle}`],
-    //     services: {
-    //       atproto_pds: {
-    //         type: 'AtprotoPersonalDataServer',
-    //         endpoint: service,
-    //       },
-    //     },
-    //     prev: legacyCid.toString(),
-    //   },
-    //   signingKey,
-    // )
     await validateOperationLog(did, [legacyOp, nextOp])
-    // await validateOperationLog(did, [legacyOp, nextOp, anotherOp])
+    await validateOperationLog(did, [legacyOp, nextOp, anotherOp])
 
-    return
     const indexedLegacy = {
       did,
       operation: legacyOp,

--- a/packages/lib/tests/data.test.ts
+++ b/packages/lib/tests/data.test.ts
@@ -155,7 +155,7 @@ describe('plc did data', () => {
 
   it('allows tombstoning a DID', async () => {
     const last = await data.getLastOpWithCid(ops)
-    const op = await operations.signTombstone(last.cid, rotationKey1)
+    const op = await operations.tombstoneOp(last.cid, rotationKey1)
     const doc = await data.validateOperationLog(did, [...ops, op])
     expect(doc).toBe(null)
   })
@@ -187,7 +187,7 @@ describe('plc did data', () => {
 
   it('does not allow a tombstone in the middle of the log', async () => {
     const prev = await cidForCbor(ops[ops.length - 2])
-    const tombstone = await operations.signTombstone(prev, rotationKey1)
+    const tombstone = await operations.tombstoneOp(prev, rotationKey1)
     expect(
       data.validateOperationLog(did, [
         ...ops.slice(0, ops.length - 1),

--- a/packages/lib/tests/data.test.ts
+++ b/packages/lib/tests/data.test.ts
@@ -73,8 +73,9 @@ describe('plc did data', () => {
   })
 
   it('updates handle', async () => {
-    handle = 'at://ali.example2.com'
-    const op = await operations.updateHandleOp(lastOp(), rotationKey1, handle)
+    const noPrefix = 'ali.exampl2.com'
+    handle = `at://${noPrefix}`
+    const op = await operations.updateHandleOp(lastOp(), rotationKey1, noPrefix)
     ops.push(op)
 
     const doc = await data.validateOperationLog(did, ops)
@@ -82,8 +83,9 @@ describe('plc did data', () => {
   })
 
   it('updates atpPds', async () => {
-    atpPds = 'https://example2.com'
-    const op = await operations.updatePdsOp(lastOp(), rotationKey1, atpPds)
+    const noPrefix = 'example2.com'
+    atpPds = `https://${noPrefix}`
+    const op = await operations.updatePdsOp(lastOp(), rotationKey1, noPrefix)
     ops.push(op)
 
     const doc = await data.validateOperationLog(did, ops)
@@ -107,7 +109,7 @@ describe('plc did data', () => {
 
   it('rotates rotation keys', async () => {
     const newRotationKey = await Secp256k1Keypair.create()
-    const op = await operations.updateRotationkeysOp(lastOp(), rotationKey1, [
+    const op = await operations.updateRotationKeysOp(lastOp(), rotationKey1, [
       newRotationKey.did(),
       rotationKey2.did(),
     ])

--- a/packages/lib/tests/document.test.ts
+++ b/packages/lib/tests/document.test.ts
@@ -32,7 +32,7 @@ describe('document', () => {
       },
     }
     const doc = await document.formatDidDoc(data)
-    // only epxected keys
+    // only expected keys
     expect(Object.keys(doc).sort()).toEqual(
       ['@context', 'id', 'alsoKnownAs', 'verificationMethod', 'service'].sort(),
     )

--- a/packages/lib/tests/document.test.ts
+++ b/packages/lib/tests/document.test.ts
@@ -5,100 +5,77 @@ import * as t from '../src/types'
 
 describe('document', () => {
   it('formats a valid DID document', async () => {
-    const signingKey = await Secp256k1Keypair.create()
+    const atprotoKey = await Secp256k1Keypair.create()
+    const otherKey = await EcdsaKeypair.create()
     const rotate1 = await Secp256k1Keypair.create()
     const rotate2 = await EcdsaKeypair.create()
-    const handles = ['alice.test', 'bob.test']
+    const alsoKnownAs = ['at://alice.test', 'https://bob.test']
     const atpPds = 'https://example.com'
+    const otherService = 'https://other.com'
     const data: t.DocumentData = {
       did: 'did:example:alice',
-      signingKey: signingKey.did(),
+      verificationMethods: {
+        atproto: atprotoKey.did(),
+        other: otherKey.did(),
+      },
       rotationKeys: [rotate1.did(), rotate2.did()],
-      handles,
+      alsoKnownAs,
       services: {
-        atpPds,
+        atproto_pds: {
+          type: 'AtprotoPersonalDataServer',
+          endpoint: atpPds,
+        },
+        other: {
+          type: 'SomeService',
+          endpoint: otherService,
+        },
       },
     }
     const doc = await document.formatDidDoc(data)
+    // only epxected keys
+    expect(Object.keys(doc).sort()).toEqual(
+      ['@context', 'id', 'alsoKnownAs', 'verificationMethod', 'service'].sort(),
+    )
     expect(doc['@context']).toEqual([
       'https://www.w3.org/ns/did/v1',
       'https://w3id.org/security/suites/secp256k1-2019/v1',
+      'https://w3id.org/security/suites/ecdsa-2019/v1',
     ])
     expect(doc.id).toEqual(data.did)
-    const formattedHandles = handles.map((h) => `https://${h}`)
-    expect(doc.alsoKnownAs).toEqual(formattedHandles)
-    expect(doc.verificationMethod.length).toBe(1)
-    expect(doc.verificationMethod[0].id).toEqual('#signingKey')
+    expect(doc.alsoKnownAs).toEqual(alsoKnownAs)
+
+    expect(doc.verificationMethod.length).toBe(2)
+
+    expect(doc.verificationMethod[0].id).toEqual('#atproto')
     expect(doc.verificationMethod[0].type).toEqual(
       'EcdsaSecp256k1VerificationKey2019',
     )
     expect(doc.verificationMethod[0].controller).toEqual(data.did)
-    const parsedSigningKey = parseDidKey(signingKey.did())
-    const signingKeyMultibase =
-      'z' + uint8arrays.toString(parsedSigningKey.keyBytes, 'base58btc')
+    const parsedAtprotoKey = parseDidKey(atprotoKey.did())
+    const atprotoKeyMultibase =
+      'z' + uint8arrays.toString(parsedAtprotoKey.keyBytes, 'base58btc')
     expect(doc.verificationMethod[0].publicKeyMultibase).toEqual(
-      signingKeyMultibase,
+      atprotoKeyMultibase,
     )
-    expect(doc.assertionMethod).toEqual(['#signingKey'])
-    expect(doc.capabilityInvocation).toEqual(['#signingKey'])
-    expect(doc.capabilityDelegation).toEqual(['#signingKey'])
-    expect(doc.service.length).toBe(1)
-    expect(doc.service[0].id).toEqual('#atpPds')
-    expect(doc.service[0].type).toEqual('AtpPersonalDataServer')
-    expect(doc.service[0].serviceEndpoint).toEqual(atpPds)
-  })
 
-  it('handles P-256 keys', async () => {
-    const signingKey = await EcdsaKeypair.create()
-    const rotate1 = await Secp256k1Keypair.create()
-    const rotate2 = await EcdsaKeypair.create()
-    const handles = ['alice.test', 'bob.test']
-    const atpPds = 'https://example.com'
-    const data: t.DocumentData = {
-      did: 'did:example:alice',
-      signingKey: signingKey.did(),
-      rotationKeys: [rotate1.did(), rotate2.did()],
-      handles,
-      services: {
-        atpPds,
-      },
-    }
-    const doc = await document.formatDidDoc(data)
-    expect(doc.verificationMethod.length).toBe(1)
-    expect(doc['@context']).toEqual([
-      'https://www.w3.org/ns/did/v1',
-      'https://w3id.org/security/suites/ecdsa-2019/v1',
-    ])
-    expect(doc.verificationMethod[0].id).toEqual('#signingKey')
-    expect(doc.verificationMethod[0].type).toEqual(
+    expect(doc.verificationMethod[1].id).toEqual('#other')
+    expect(doc.verificationMethod[1].type).toEqual(
       'EcdsaSecp256r1VerificationKey2019',
     )
-    expect(doc.verificationMethod[0].controller).toEqual(data.did)
-    const parsedSigningKey = parseDidKey(signingKey.did())
-    const signingKeyMultibase =
-      'z' + uint8arrays.toString(parsedSigningKey.keyBytes, 'base58btc')
-    expect(doc.verificationMethod[0].publicKeyMultibase).toEqual(
-      signingKeyMultibase,
+    expect(doc.verificationMethod[1].controller).toEqual(data.did)
+    const parsedOtherKey = parseDidKey(otherKey.did())
+    const otherKeyMultibase =
+      'z' + uint8arrays.toString(parsedOtherKey.keyBytes, 'base58btc')
+    expect(doc.verificationMethod[1].publicKeyMultibase).toEqual(
+      otherKeyMultibase,
     )
-  })
 
-  it('formats a valid DID document regardless of leading https://', async () => {
-    const signingKey = await Secp256k1Keypair.create()
-    const rotate1 = await Secp256k1Keypair.create()
-    const rotate2 = await EcdsaKeypair.create()
-    const handles = ['https://alice.test', 'bob.test']
-    const atpPds = 'example.com'
-    const data: t.DocumentData = {
-      did: 'did:example:alice',
-      signingKey: signingKey.did(),
-      rotationKeys: [rotate1.did(), rotate2.did()],
-      handles,
-      services: {
-        atpPds,
-      },
-    }
-    const doc = await document.formatDidDoc(data)
-    expect(doc.alsoKnownAs).toEqual(['https://alice.test', 'https://bob.test'])
-    expect(doc.service[0].serviceEndpoint).toEqual(`https://${atpPds}`)
+    expect(doc.service.length).toBe(2)
+    expect(doc.service[0].id).toEqual('#atproto_pds')
+    expect(doc.service[0].type).toEqual('AtprotoPersonalDataServer')
+    expect(doc.service[0].serviceEndpoint).toEqual(atpPds)
+    expect(doc.service[1].id).toEqual('#other')
+    expect(doc.service[1].type).toEqual('SomeService')
+    expect(doc.service[1].serviceEndpoint).toEqual(otherService)
   })
 })

--- a/packages/lib/tests/recovery.test.ts
+++ b/packages/lib/tests/recovery.test.ts
@@ -46,19 +46,17 @@ describe('plc recovery', () => {
     signer: Keypair,
     otherChanges: Partial<t.Operation> = {},
   ) => {
-    const op = await operations.signOperation(
-      {
+    const unsigned = {
+      ...operations.formatAtprotoOp({
         signingKey: signingKey.did(),
         rotationKeys: keys.map((k) => k.did()),
-        handles: [handle],
-        services: {
-          atpPds,
-        },
-        prev: prev ? prev.toString() : null,
-        ...otherChanges,
-      },
-      signer,
-    )
+        handle,
+        pds: atpPds,
+        prev,
+      }),
+      ...otherChanges,
+    }
+    const op = await operations.addSignature(unsigned, signer)
     const indexed = await formatIndexed(op)
     return { op, indexed }
   }
@@ -89,7 +87,7 @@ describe('plc recovery', () => {
       [rotationKey3],
       rotate.indexed.cid,
       rotationKey3,
-      { handles: ['newhandle.test'] },
+      { alsoKnownAs: ['newhandle.test'] },
     )
 
     log.push({

--- a/packages/lib/tests/recovery.test.ts
+++ b/packages/lib/tests/recovery.test.ts
@@ -159,7 +159,7 @@ describe('plc recovery', () => {
   })
 
   it('allows recovery from a tombstoned DID', async () => {
-    const tombstone = await operations.signTombstone(createCid, rotationKey2)
+    const tombstone = await operations.tombstoneOp(createCid, rotationKey2)
     const cid = await cidForCbor(tombstone)
     const tombstoneOps = [
       log[0],

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -92,7 +92,10 @@ export class Database implements PlcDatabase {
     return results
   }
 
-  async validateAndAddOp(did: string, proposed: plc.Operation): Promise<void> {
+  async validateAndAddOp(
+    did: string,
+    proposed: plc.OpOrTombstone,
+  ): Promise<void> {
     const ops = await this.indexedOpsForDid(did)
     // throws if invalid
     const { nullified, prev } = await plc.assureValidNextOp(did, ops, proposed)

--- a/packages/server/src/db/mock.ts
+++ b/packages/server/src/db/mock.ts
@@ -11,7 +11,10 @@ export class MockDatabase implements PlcDatabase {
   async close(): Promise<void> {}
   async healthCheck(): Promise<void> {}
 
-  async validateAndAddOp(did: string, proposed: plc.Operation): Promise<void> {
+  async validateAndAddOp(
+    did: string,
+    proposed: plc.OpOrTombstone,
+  ): Promise<void> {
     this.contents[did] ??= []
     const opsBefore = this.contents[did]
     // throws if invalid

--- a/packages/server/src/db/types.ts
+++ b/packages/server/src/db/types.ts
@@ -4,7 +4,7 @@ import { Generated } from 'kysely'
 export interface PlcDatabase {
   close(): Promise<void>
   healthCheck(): Promise<void>
-  validateAndAddOp(did: string, proposed: plc.Operation): Promise<void>
+  validateAndAddOp(did: string, proposed: plc.OpOrTombstone): Promise<void>
   opsForDid(did: string): Promise<plc.CompatibleOpOrTombstone[]>
   indexedOpsForDid(
     did: string,

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -106,7 +106,7 @@ export const createRouter = (ctx: AppContext): express.Router => {
   router.post('/:did', async function (req, res) {
     const { did } = req.params
     const op = req.body
-    if (!check.is(op, plc.def.operation)) {
+    if (!check.is(op, plc.def.opOrTombstone)) {
       throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)
     }
     await ctx.db.validateAndAddOp(did, op)

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -1,14 +1,13 @@
 import { EcdsaKeypair } from '@atproto/crypto'
 import * as plc from '@did-plc/lib'
 import { CloseFn, runTestServer } from './_util'
-import { check, cidForCbor } from '@atproto/common'
+import { check } from '@atproto/common'
 import { AxiosError } from 'axios'
 import { Database } from '../src'
-import { signOperation } from '@did-plc/lib'
 
 describe('PLC server', () => {
-  let handle = 'alice.example.com'
-  let atpPds = 'example.com'
+  let handle = 'at://alice.example.com'
+  let atpPds = 'https://example.com'
 
   let close: CloseFn
   let db: Database
@@ -39,57 +38,55 @@ describe('PLC server', () => {
     }
   })
 
-  it('registers a did', async () => {
-    did = await client.create(
-      {
-        signingKey: signingKey.did(),
-        rotationKeys: [rotationKey1.did(), rotationKey2.did()],
-        handles: [handle],
-        services: {
-          atpPds,
-        },
+  const verifyDoc = (doc: plc.DocumentData | null) => {
+    if (!doc) {
+      throw new Error('expected doc')
+    }
+    expect(doc.did).toEqual(did)
+    expect(doc.verificationMethods).toEqual({ atproto: signingKey.did() })
+    expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
+    expect(doc.alsoKnownAs).toEqual([handle])
+    expect(doc.services).toEqual({
+      atproto_pds: {
+        type: 'AtprotoPersonalDataServer',
+        endpoint: atpPds,
       },
-      rotationKey1,
-    )
+    })
+  }
+
+  it('registers a did', async () => {
+    did = await client.createDid({
+      signingKey: signingKey.did(),
+      rotationKeys: [rotationKey1.did(), rotationKey2.did()],
+      handle,
+      pds: atpPds,
+      signer: rotationKey1,
+    })
   })
 
   it('retrieves did doc data', async () => {
     const doc = await client.getDocumentData(did)
-    expect(doc.did).toEqual(did)
-    expect(doc.signingKey).toEqual(signingKey.did())
-    expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
-    expect(doc.handles).toEqual([handle])
-    expect(doc.services).toEqual({ atpPds })
+    verifyDoc(doc)
   })
 
   it('can perform some updates', async () => {
     const newRotationKey = await EcdsaKeypair.create()
     signingKey = await EcdsaKeypair.create()
-    handle = 'ali.example2.com'
-    atpPds = 'example2.com'
+    handle = 'at://ali.example2.com'
+    atpPds = 'https://example2.com'
 
-    await client.applyPartialOp(
-      did,
-      { signingKey: signingKey.did() },
-      rotationKey1,
-    )
-
-    await client.applyPartialOp(
-      did,
-      { rotationKeys: [newRotationKey.did(), rotationKey2.did()] },
-      rotationKey1,
-    )
+    await client.updateAtprotoKey(did, rotationKey1, signingKey.did())
+    await client.updateRotationKeys(did, rotationKey1, [
+      newRotationKey.did(),
+      rotationKey2.did(),
+    ])
     rotationKey1 = newRotationKey
 
-    await client.applyPartialOp(did, { handles: [handle] }, rotationKey1)
-    await client.applyPartialOp(did, { services: { atpPds } }, rotationKey1)
+    await client.updateHandle(did, rotationKey1, handle)
+    await client.updatePds(did, rotationKey1, atpPds)
 
     const doc = await client.getDocumentData(did)
-    expect(doc.did).toEqual(did)
-    expect(doc.signingKey).toEqual(signingKey.did())
-    expect(doc.rotationKeys).toEqual([rotationKey1.did(), rotationKey2.did()])
-    expect(doc.handles).toEqual([handle])
-    expect(doc.services).toEqual({ atpPds })
+    verifyDoc(doc)
   })
 
   it('does not allow key types that we do not support', async () => {
@@ -97,12 +94,13 @@ describe('PLC server', () => {
     const newSigningKey =
       'did:key:z6MkjwbBXZnFqL8su24wGL2Fdjti6GSLv9SWdYGswfazUPm9'
 
-    const promise = client.applyPartialOp(
-      did,
-      { signingKey: newSigningKey },
-      rotationKey1,
-    )
+    const promise = client.updateAtprotoKey(did, rotationKey1, newSigningKey)
     await expect(promise).rejects.toThrow(AxiosError)
+
+    const promise2 = client.updateRotationKeys(did, rotationKey1, [
+      newSigningKey,
+    ])
+    await expect(promise2).rejects.toThrow(AxiosError)
   })
 
   it('retrieves the operation log', async () => {
@@ -114,21 +112,13 @@ describe('PLC server', () => {
 
   it('rejects on bad updates', async () => {
     const newKey = await EcdsaKeypair.create()
-    const operation = client.applyPartialOp(
-      did,
-      { signingKey: newKey.did() },
-      newKey,
-    )
+    const operation = client.updateAtprotoKey(did, newKey, newKey.did())
     await expect(operation).rejects.toThrow()
   })
 
   it('allows for recovery through a forked history', async () => {
     const attackerKey = await EcdsaKeypair.create()
-    await client.applyPartialOp(
-      did,
-      { signingKey: attackerKey.did(), rotationKeys: [attackerKey.did()] },
-      rotationKey2,
-    )
+    await client.updateRotationKeys(did, rotationKey2, [attackerKey.did()])
 
     const newKey = await EcdsaKeypair.create()
     const ops = await client.getOperationLog(did)
@@ -136,27 +126,16 @@ describe('PLC server', () => {
     if (!check.is(forkPoint, plc.def.operation)) {
       throw new Error('Could not find fork point')
     }
-    const forkCid = await cidForCbor(forkPoint)
-    const op = await signOperation(
-      {
-        signingKey: signingKey.did(),
-        rotationKeys: [newKey.did()],
-        handles: forkPoint.handles,
-        services: forkPoint.services,
-        prev: forkCid.toString(),
-      },
-      rotationKey1,
-    )
+    const op = await plc.updateRotationKeysOp(forkPoint, rotationKey1, [
+      rotationKey1.did(),
+      newKey.did(),
+    ])
     await client.sendOperation(did, op)
 
-    rotationKey1 = newKey
+    rotationKey2 = newKey
 
     const doc = await client.getDocumentData(did)
-    expect(doc.did).toEqual(did)
-    expect(doc.signingKey).toEqual(signingKey.did())
-    expect(doc.rotationKeys).toEqual([newKey.did()])
-    expect(doc.handles).toEqual([handle])
-    expect(doc.services).toEqual({ atpPds })
+    verifyDoc(doc)
   })
 
   it('retrieves the auditable operation log', async () => {
@@ -185,17 +164,13 @@ describe('PLC server', () => {
     }
     await Promise.all(
       keys.map(async (key, index) => {
-        await client.create(
-          {
-            signingKey: key.did(),
-            rotationKeys: [key.did()],
-            handles: [`user${index}`],
-            services: {
-              atpPds: `example.com`,
-            },
-          },
-          key,
-        )
+        await client.createDid({
+          signingKey: key.did(),
+          rotationKeys: [key.did()],
+          handle: `user${index}`,
+          pds: `example.com`,
+          signer: key,
+        })
       }),
     )
   })
@@ -213,11 +188,7 @@ describe('PLC server', () => {
     await Promise.all(
       keys.map(async (key) => {
         try {
-          await client.applyPartialOp(
-            did,
-            { signingKey: key.did() },
-            rotationKey1,
-          )
+          await client.updateAtprotoKey(did, rotationKey1, key.did())
           successes++
         } catch (err) {
           failures++

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -202,10 +202,19 @@ describe('PLC server', () => {
     await plc.validateOperationLog(did, ops)
   })
 
+  it('tombstones the did', async () => {
+    await client.tombstone(did, rotationKey1)
+
+    const promise = client.getDocument(did)
+    await expect(promise).rejects.toThrow(AxiosError)
+    const promise2 = client.getDocumentData(did)
+    await expect(promise2).rejects.toThrow(AxiosError)
+  })
+
   it('exports the data set', async () => {
     const data = await client.export()
     expect(data.every((row) => check.is(row, plc.def.exportedOp))).toBeTruthy()
-    expect(data.length).toBe(58)
+    expect(data.length).toBe(59)
     for (let i = 1; i < data.length; i++) {
       expect(data[i].createdAt >= data[i - 1].createdAt).toBeTruthy()
     }


### PR DESCRIPTION
This updates our data model so that it more closely mirrors did doc semantics.

Namely:
- updating "handle" to "alsoKnownAs"
- updating "services" to a map
- updating "signingKey" to "verificationMethods"

We have room to add in additional did doc semantics - such as verification relationships - in future work.

This also introduces some operation formatters on both the client & the library for easily working with atproto formatted DIDs