### PR TITLE
CI: run on pull requests, not just pushes

### DIFF
--- a/.github/workflows/build-test-verify.yaml
+++ b/.github/workflows/build-test-verify.yaml
@@ -1,5 +1,12 @@
 name: build-test-verify
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is identical to the `atproto` PR which just merged: https://github.com/bluesky-social/atproto/pull/669