### PR TITLE
add dotenv package; remove .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ packages/*/coverage
 .DS_Store
 *.log
 tsconfig.build.tsbuildinfo
-.dev.env
+.env
+.*.env
 \#*\#
 *~
 *.swp

--- a/packages/server/.env
+++ b/packages/server/.env
@@ -1,1 +1,0 @@
-DATABASE_LOC=""

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -28,6 +28,7 @@
     "@did-plc/lib": "*",
     "axios": "^1.3.4",
     "cors": "^2.8.5",
+    "dotenv": "^16.0.0",
     "express": "^4.18.2",
     "express-async-errors": "^3.1.1",
     "http-terminator": "^3.2.0",


### PR DESCRIPTION
The dotenv issue impacts having a docker-compose setup for cross-language interop tests, at least using the naive `yarn run start` setup (as opposed to full non-dev-mode service entry point) 