### PR TITLE
Dockerfile: use default PLC port (2582)

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -26,8 +26,8 @@ ENTRYPOINT ["dumb-init", "--"]
 WORKDIR /app/packages/server/service
 COPY --from=build /app /app
 
-EXPOSE 3000
-ENV PORT=3000
+EXPOSE 2582
+ENV PORT=2582
 ENV NODE_ENV=production
 
 # https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md#non-root-user


### PR DESCRIPTION
DON'T MERGE/DEPLOY WITHOUT PULUMI UPDATES

I'm not sure why the default was 3000; maybe it is actually intentional to have a generic port instead of the default PLC-specific port used for other testing?

This isn't urgent for anything I am doing right now, but is a confusing developer experience I think. I would expect this PR to linger for a couple weeks, just want to track the issue.

The Pulumi deployment/config expects port 3000 so don't actually merge this as-is.

cc: @Jacob2161 @emilyliu7321