### PR TITLE
Increase flexibility of paramaters accepted by DB_CREDS_JSON env var

### DIFF
--- a/packages/server/service/index.js
+++ b/packages/server/service/index.js
@@ -29,7 +29,7 @@ const main = async () => {
   })
 }
 
-const pgUrl = ({ username = "postgres", password = "postgres", host = "0.0.0.0", port = "5432", database = "postgres", sslmode }) => {
+const pgUrl = ({ username = "postgres", password = "postgres", host = "localhost", port = "5432", database = "postgres", sslmode }) => {
   const enc = encodeURIComponent
   return `postgresql://${username}:${enc(password)}@${host}:${port}/${database}${sslmode ? `?sslmode=${enc(sslmode)}` : ''}`
 }

--- a/packages/server/service/index.js
+++ b/packages/server/service/index.js
@@ -29,9 +29,9 @@ const main = async () => {
   })
 }
 
-const pgUrl = ({ username, password, host, port }) => {
+const pgUrl = ({ username = "postgres", password = "postgres", host = "0.0.0.0", port = "5432", database = "postgres", sslmode }) => {
   const enc = encodeURIComponent
-  return `postgresql://${username}:${enc(password)}@${host}:${port}/postgres`
+  return `postgresql://${username}:${enc(password)}@${host}:${port}/${database}${sslmode ? `?sslmode=${enc(sslmode)}` : ''}`
 }
 
 main()


### PR DESCRIPTION
_Parallel of https://github.com/bluesky-social/atproto/pull/974_

## Summary

- Added default values for the `username`, `password`, `host`, `port`, and `database` parameters of the `pgUrl` function.
- Added an optional `sslmode` parameter to the `pgUrl` function.
- These default values are intended to ensure that the `pgUrl` function can still connect to the PostgreSQL database even if not all the parameters are provided.

## Examples

### 1. With original options:

```json
{
  "username": "myuser",
  "password": "mypassword",
  "host": "localhost",
  "port": "5432"
}
```

Output:

```
postgresql://myuser:mypassword@localhost:5432/postgres
```

### 2. With new options including `sslmode`:

```json
{
  "username": "myuser",
  "password": "mypassword",
  "host": "localhost",
  "port": "5432",
  "database": "mydb",
  "sslmode": "require"
}
```

Output:

```
postgresql://myuser:mypassword@localhost:5432/mydb?sslmode=require
```