### PR TITLE
server: redirect / to github repo

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -7,6 +7,11 @@ import { AppContext } from './context'
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
 
+  router.get('/', async function (req, res) {
+    // HTTP temporary redirect to project git repo
+    res.redirect(302, 'https://github.com/bluesky-social/did-method-plc')
+  })
+
   router.get('/_health', async function (req, res) {
     const { db, version } = ctx
     try {


### PR DESCRIPTION
imagine that there should be a nice homepage, or interactive DID explorer, or any number of things, but this is better than the current `Cannot GET /`.

also considered redirecting to https://atproto.com/specs/did-plc, but this felt more inline with did:plc being multi-use and general beyond bluesky and atproto.