### PR TITLE
tiny tweaks

### DIFF
--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -77,6 +77,7 @@ export const createUpdateOp = async (
 ): Promise<t.Operation> => {
   const prev = await cidForCbor(lastOp)
   // omit sig so it doesn't accidentally make its way into the next operation
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { sig, ...normalized } = normalizeOp(lastOp)
   const unsigned = await fn(normalized)
   return addSignature(

--- a/packages/lib/src/operations.ts
+++ b/packages/lib/src/operations.ts
@@ -289,16 +289,16 @@ export const assureValidCreationOp = async (
 }
 
 export const assureValidSig = async (
-  allowedDids: string[],
+  allowedDidKeys: string[],
   op: t.CompatibleOpOrTombstone,
 ): Promise<string> => {
   const { sig, ...opData } = op
   const sigBytes = uint8arrays.fromString(sig, 'base64url')
   const dataBytes = new Uint8Array(cbor.encode(opData))
-  for (const did of allowedDids) {
-    const isValid = await verifySignature(did, dataBytes, sigBytes)
+  for (const didKey of allowedDidKeys) {
+    const isValid = await verifySignature(didKey, dataBytes, sigBytes)
     if (isValid) {
-      return did
+      return didKey
     }
   }
   throw new InvalidSignatureError(op)


### PR DESCRIPTION
Was confused by `allowedDids` when skimming the code, `allowedDidKeys` is clearer.

Got a lint warning (but not lint error) when running `make lint`. Addressed with an `eslint` comment, though maybe there is a more idiomatic Typescript way to handle it.