### PR TITLE
Increase server keepalive to be in sync with common load balancers

### DIFF
--- a/packages/server/service/index.js
+++ b/packages/server/service/index.js
@@ -22,7 +22,8 @@ const main = async () => {
   })
   const port = parseInt(process.env.PORT)
   const plc = PlcServer.create({ db, port, version })
-  await plc.start()
+  const server = await plc.start()
+  server.keepAliveTimeout = 90000
   // Graceful shutdown (see also https://aws.amazon.com/blogs/containers/graceful-shutdowns-with-ecs/)
   process.on('SIGTERM', async () => {
     await plc.destroy()


### PR DESCRIPTION
Want to ensure the keepalive is at least as long as a load balancer's idle timeout.  An idle timeout of 60sec is common, so 90sec should do the trick.