### PR TITLE
README: de-emphasize 'placeholder' name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DID Placeholder Method (did:plc)
+# DID PLC Method (did:plc)
 
-DID Placeholder is a self-authenticating [DID](https://www.w3.org/TR/did-core/) which is strongly-consistent, recoverable, and allows for key rotation.
+DID PLC is a self-authenticating [DID](https://www.w3.org/TR/did-core/) which is strongly-consistent, recoverable, and allows for key rotation.
 
 An example DID is: `did:plc:yk4dd2qkboz2yv6tpubpc6co`
 
@@ -8,10 +8,10 @@ Control over a `did:plc` identity rests in a set of re-configurable "rotation" k
 
 ## Motivation
 
-[Bluesky](https://blueskyweb.xyz/) developed DID Placeholder when designing the [AT Protocol](https://atproto.com) ("atproto") because we were not satisfied with any of the existing DID methods.
+[Bluesky](https://blueskyweb.xyz/) developed DID PLC when designing the [AT Protocol](https://atproto.com) ("atproto") because we were not satisfied with any of the existing DID methods.
 We wanted a strongly consistent, highly available, recoverable, and cryptographically secure method with fast and cheap propagation of updates.
 
-We titled the method "Placeholder", because we _don't_ want it to stick around forever in its current form. We are actively hoping to replace it with or evolve it into something less centralized - likely a permissioned DID consortium. That being said, we do intend to support `did:plc` in the current form until after any successor is deployed, with a reasonable grace period. We would also provide a migration route to allow continued use of existing `did:plc` identifiers.
+We originally titled the method "Placeholder", because we didn't want it to stick around forever in its current form. We are actively hoping to replace it with or evolve it into something less centralized - likely a permissioned DID consortium. That being said, we do intend to support `did:plc` in the current form until after any successor is deployed, with a reasonable grace period. We would also provide a migration route to allow continued use of existing `did:plc` identifiers.
 
 ## How it works
 
@@ -99,7 +99,7 @@ In pseudo-code:
 
 ### Identifier Syntax
 
-The DID Placeholder method name is `plc`. The identifier part is 24 characters
+The DID PLC method name is `plc`. The identifier part is 24 characters
 long, including only characters from the `base32` encoding set. An example is
 `did:plc:yk4dd2qkboz2yv6tpubpc6co`. This means:
 


### PR DESCRIPTION
Walking back the narrative a bit here, so we don't drive devs and standards folks off right out of the gate.