### PR TITLE
Require bluesky-social/did-method-plc for Container Build & Push

### DIFF
--- a/.github/workflows/build-and-push-aws.yaml
+++ b/.github/workflows/build-and-push-aws.yaml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   plc-container-aws:
+    if: github.repository == 'bluesky-social/did-method-plc'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-push-ghcr.yaml
+++ b/.github/workflows/build-and-push-ghcr.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   plc-container-ghcr:
+    if: github.repository == 'bluesky-social/did-method-plc'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Counterpart: https://github.com/bluesky-social/atproto/pull/1460

This PR runs the actions only for the original `bluesky-social/did-method-plc` repository on the main branch.

Do not merge if you wish to build and push main branches from other repositories.