### PR TITLE
update to newer @atproto deps

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -19,8 +19,8 @@
     "postpublish": "npm run update-main-to-src"
   },
   "dependencies": {
-    "@atproto/common": "0.1.1",
-    "@atproto/crypto": "0.1.0",
+    "@atproto/common": "0.3.0",
+    "@atproto/crypto": "0.2.0",
     "@ipld/dag-cbor": "^7.0.3",
     "axios": "^1.3.4",
     "multiformats": "^9.6.4",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@did-plc/lib",
   "version": "0.0.4",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "test": "jest",
@@ -20,12 +20,12 @@
   },
   "dependencies": {
     "@atproto/common": "0.3.0",
-    "@atproto/crypto": "0.2.0",
+    "@atproto/crypto": "0.2.2",
     "@ipld/dag-cbor": "^7.0.3",
     "axios": "^1.3.4",
     "multiformats": "^9.6.4",
     "uint8arrays": "3.0.0",
-    "zod": "^3.14.2"
+    "zod": "^3.21.4"
   },
   "devDependencies": {
     "eslint-plugin-prettier": "^4.2.1"

--- a/packages/lib/src/document.ts
+++ b/packages/lib/src/document.ts
@@ -2,7 +2,7 @@ import * as uint8arrays from 'uint8arrays'
 import * as crypto from '@atproto/crypto'
 import * as t from './types'
 import { UnsupportedKeyError } from './error'
-import { ParsedDidKey } from '@atproto/crypto'
+import { ParsedMultikey } from '@atproto/crypto'
 
 export const formatDidDoc = (data: t.DocumentData): t.DidDocument => {
   const context = ['https://www.w3.org/ns/did/v1']
@@ -59,7 +59,7 @@ type KeyAndContext = {
 }
 
 const formatKeyAndContext = (key: string): KeyAndContext => {
-  let keyInfo: ParsedDidKey
+  let keyInfo: ParsedMultikey
   try {
     keyInfo = crypto.parseDidKey(key)
   } catch (err) {

--- a/packages/lib/tests/data.test.ts
+++ b/packages/lib/tests/data.test.ts
@@ -1,5 +1,5 @@
 import { check, cidForCbor } from '@atproto/common'
-import { EcdsaKeypair, Secp256k1Keypair } from '@atproto/crypto'
+import { P256Keypair, Secp256k1Keypair } from '@atproto/crypto'
 import {
   GenesisHashError,
   ImproperOperationError,
@@ -15,7 +15,7 @@ describe('plc did data', () => {
 
   let signingKey: Secp256k1Keypair
   let rotationKey1: Secp256k1Keypair
-  let rotationKey2: EcdsaKeypair
+  let rotationKey2: P256Keypair
   let did: string
   let handle = 'at://alice.example.com'
   let atpPds = 'https://example.com'
@@ -25,7 +25,7 @@ describe('plc did data', () => {
   beforeAll(async () => {
     signingKey = await Secp256k1Keypair.create()
     rotationKey1 = await Secp256k1Keypair.create()
-    rotationKey2 = await EcdsaKeypair.create()
+    rotationKey2 = await P256Keypair.create()
   })
 
   const lastOp = () => {

--- a/packages/lib/tests/document.test.ts
+++ b/packages/lib/tests/document.test.ts
@@ -1,14 +1,14 @@
 import * as uint8arrays from 'uint8arrays'
-import { EcdsaKeypair, parseDidKey, Secp256k1Keypair } from '@atproto/crypto'
+import { P256Keypair, parseDidKey, Secp256k1Keypair } from '@atproto/crypto'
 import * as document from '../src/document'
 import * as t from '../src/types'
 
 describe('document', () => {
   it('formats a valid DID document', async () => {
     const atprotoKey = await Secp256k1Keypair.create()
-    const otherKey = await EcdsaKeypair.create()
+    const otherKey = await P256Keypair.create()
     const rotate1 = await Secp256k1Keypair.create()
-    const rotate2 = await EcdsaKeypair.create()
+    const rotate2 = await P256Keypair.create()
     const alsoKnownAs = ['at://alice.test', 'https://bob.test']
     const atpPds = 'https://example.com'
     const otherService = 'https://other.com'

--- a/packages/lib/tests/recovery.test.ts
+++ b/packages/lib/tests/recovery.test.ts
@@ -1,5 +1,5 @@
 import { cidForCbor, DAY, HOUR } from '@atproto/common'
-import { EcdsaKeypair, Keypair, Secp256k1Keypair } from '@atproto/crypto'
+import { P256Keypair, Keypair, Secp256k1Keypair } from '@atproto/crypto'
 import { CID } from 'multiformats/cid'
 import { InvalidSignatureError, LateRecoveryError } from '../src'
 import * as data from '../src/data'
@@ -9,8 +9,8 @@ import * as t from '../src/types'
 describe('plc recovery', () => {
   let signingKey: Secp256k1Keypair
   let rotationKey1: Secp256k1Keypair
-  let rotationKey2: EcdsaKeypair
-  let rotationKey3: EcdsaKeypair
+  let rotationKey2: P256Keypair
+  let rotationKey3: P256Keypair
   let did: string
   const handle = 'alice.example.com'
   const atpPds = 'https://example.com'
@@ -22,8 +22,8 @@ describe('plc recovery', () => {
   beforeAll(async () => {
     signingKey = await Secp256k1Keypair.create()
     rotationKey1 = await Secp256k1Keypair.create()
-    rotationKey2 = await EcdsaKeypair.create()
-    rotationKey3 = await EcdsaKeypair.create()
+    rotationKey2 = await P256Keypair.create()
+    rotationKey3 = await P256Keypair.create()
   })
 
   const formatIndexed = async (

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -23,8 +23,8 @@
     "postpublish": "npm run update-main-to-src"
   },
   "dependencies": {
-    "@atproto/common": "0.1.1",
-    "@atproto/crypto": "0.1.0",
+    "@atproto/common": "0.3.0",
+    "@atproto/crypto": "0.2.0",
     "@did-plc/lib": "*",
     "axios": "^1.3.4",
     "cors": "^2.8.5",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@atproto/common": "0.3.0",
-    "@atproto/crypto": "0.2.0",
+    "@atproto/crypto": "0.2.2",
     "@did-plc/lib": "*",
     "axios": "^1.3.4",
     "cors": "^2.8.5",

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -1,4 +1,4 @@
-import { EcdsaKeypair } from '@atproto/crypto'
+import { P256Keypair } from '@atproto/crypto'
 import * as plc from '@did-plc/lib'
 import { CloseFn, runTestServer } from './_util'
 import { check } from '@atproto/common'
@@ -13,9 +13,9 @@ describe('PLC server', () => {
   let db: Database
   let client: plc.Client
 
-  let signingKey: EcdsaKeypair
-  let rotationKey1: EcdsaKeypair
-  let rotationKey2: EcdsaKeypair
+  let signingKey: P256Keypair
+  let rotationKey1: P256Keypair
+  let rotationKey2: P256Keypair
 
   let did: string
 
@@ -27,9 +27,9 @@ describe('PLC server', () => {
     db = server.db
     close = server.close
     client = new plc.Client(server.url)
-    signingKey = await EcdsaKeypair.create()
-    rotationKey1 = await EcdsaKeypair.create()
-    rotationKey2 = await EcdsaKeypair.create()
+    signingKey = await P256Keypair.create()
+    rotationKey1 = await P256Keypair.create()
+    rotationKey2 = await P256Keypair.create()
   })
 
   afterAll(async () => {
@@ -70,8 +70,8 @@ describe('PLC server', () => {
   })
 
   it('can perform some updates', async () => {
-    const newRotationKey = await EcdsaKeypair.create()
-    signingKey = await EcdsaKeypair.create()
+    const newRotationKey = await P256Keypair.create()
+    signingKey = await P256Keypair.create()
     handle = 'at://ali.example2.com'
     atpPds = 'https://example2.com'
 
@@ -111,16 +111,16 @@ describe('PLC server', () => {
   })
 
   it('rejects on bad updates', async () => {
-    const newKey = await EcdsaKeypair.create()
+    const newKey = await P256Keypair.create()
     const operation = client.updateAtprotoKey(did, newKey, newKey.did())
     await expect(operation).rejects.toThrow()
   })
 
   it('allows for recovery through a forked history', async () => {
-    const attackerKey = await EcdsaKeypair.create()
+    const attackerKey = await P256Keypair.create()
     await client.updateRotationKeys(did, rotationKey2, [attackerKey.did()])
 
-    const newKey = await EcdsaKeypair.create()
+    const newKey = await P256Keypair.create()
     const ops = await client.getOperationLog(did)
     const forkPoint = ops.at(-2)
     if (!check.is(forkPoint, plc.def.operation)) {
@@ -158,9 +158,9 @@ describe('PLC server', () => {
 
   it('handles concurrent requests to many docs', async () => {
     const COUNT = 20
-    const keys: EcdsaKeypair[] = []
+    const keys: P256Keypair[] = []
     for (let i = 0; i < COUNT; i++) {
-      keys.push(await EcdsaKeypair.create())
+      keys.push(await P256Keypair.create())
     }
     await Promise.all(
       keys.map(async (key, index) => {
@@ -177,9 +177,9 @@ describe('PLC server', () => {
 
   it('resolves races into a coherent history with no forks', async () => {
     const COUNT = 20
-    const keys: EcdsaKeypair[] = []
+    const keys: P256Keypair[] = []
     for (let i = 0; i < COUNT; i++) {
-      keys.push(await EcdsaKeypair.create())
+      keys.push(await P256Keypair.create())
     }
     // const prev = await client.getPrev(did)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,25 +10,34 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@atproto/common@0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@atproto/common/-/common-0.1.1.tgz#ec33a3b4995c91d3ad2e90fc4cdbc65284ceff84"
-  integrity sha512-GYwot5wF/z8iYGSPjrLHuratLc0CVgovmwfJss7+BUOB6y2/Vw8+1Vw0n9DDI0gb5vmx3UI8z0uJgC8aa8yuJg==
+"@atproto/common-web@*":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.2.0.tgz#8420da28e89dac64ad2a11b6ff10a4023c67151f"
+  integrity sha512-ugKrT8CWf6PDsZ29VOhOCs5K4z9BAFIV7SxPXA+MHC7pINqQ+wyjIq+DtUI8kmUSce1dTqc/lMN1akf/W5whVQ==
   dependencies:
+    graphemer "^1.4.0"
+    multiformats "^9.6.4"
+    uint8arrays "3.0.0"
+    zod "^3.21.4"
+
+"@atproto/common@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@atproto/common/-/common-0.3.0.tgz#6ddb0a9bedbf9058353a241b056ae83539da3539"
+  integrity sha512-R5d50Da63wQdAYaHe+rne5nM/rSYIWBaDZtVKpluysG86U1rRIgrG4qEQ/tNDt6WzYcxKXkX4EOeVvGtav2twg==
+  dependencies:
+    "@atproto/common-web" "*"
     "@ipld/dag-cbor" "^7.0.3"
+    cbor-x "^1.5.1"
     multiformats "^9.6.4"
     pino "^8.6.1"
-    zod "^3.14.2"
 
-"@atproto/crypto@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@atproto/crypto/-/crypto-0.1.0.tgz#bc73a479f9dbe06fa025301c182d7f7ab01bc568"
-  integrity sha512-9xgFEPtsCiJEPt9o3HtJT30IdFTGw5cQRSJVIy5CFhqBA4vDLcdXiRDLCjkzHEVbtNCsHUW6CrlfOgbeLPcmcg==
+"@atproto/crypto@0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@atproto/crypto/-/crypto-0.2.2.tgz#9832dda885512a36401d24f95990489f521593ef"
+  integrity sha512-yepwM6pLPw/bT7Nl0nfDw251yVDpuhc0llOgD8YdCapUAH7pIn4dBcMgXiA9UzQaHA7OC9ByO5IdGPrMN/DmZw==
   dependencies:
-    "@noble/secp256k1" "^1.7.0"
-    big-integer "^1.6.51"
-    multiformats "^9.6.4"
-    one-webcrypto "^1.0.3"
+    "@noble/curves" "^1.1.0"
+    "@noble/hashes" "^1.3.1"
     uint8arrays "3.0.0"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.18.6":
@@ -949,6 +958,36 @@
   version "0.2.3"
   resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
+"@cbor-extract/cbor-extract-darwin-arm64@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.1.1.tgz#5721f6dd3feae0b96d23122853ce977e0671b7a6"
+  integrity sha512-blVBy5MXz6m36Vx0DfLd7PChOQKEs8lK2bD1WJn/vVgG4FXZiZmZb2GECHFvVPA5T7OnODd9xZiL3nMCv6QUhA==
+
+"@cbor-extract/cbor-extract-darwin-x64@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.1.1.tgz#c25e7d0133950d87d101d7b3afafea8d50d83f5f"
+  integrity sha512-h6KFOzqk8jXTvkOftyRIWGrd7sKQzQv2jVdTL9nKSf3D2drCvQB/LHUxAOpPXo3pv2clDtKs3xnHalpEh3rDsw==
+
+"@cbor-extract/cbor-extract-linux-arm64@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.1.1.tgz#48f78e7d8f0fcc84ed074b6bfa6d15dd83187c63"
+  integrity sha512-SxAaRcYf8S0QHaMc7gvRSiTSr7nUYMqbUdErBEu+HYA4Q6UNydx1VwFE68hGcp1qvxcy9yT5U7gA+a5XikfwSQ==
+
+"@cbor-extract/cbor-extract-linux-arm@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.1.1.tgz#7507d346389cb682e44fab8fae9534edd52e2e41"
+  integrity sha512-ds0uikdcIGUjPyraV4oJqyVE5gl/qYBpa/Wnh6l6xLE2lj/hwnjT2XcZCChdXwW/YFZ1LUHs6waoYN8PmK0nKQ==
+
+"@cbor-extract/cbor-extract-linux-x64@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.1.1.tgz#b7c1d2be61c58ec18d58afbad52411ded63cd4cd"
+  integrity sha512-GVK+8fNIE9lJQHAlhOROYiI0Yd4bAZ4u++C2ZjlkS3YmO6hi+FUxe6Dqm+OKWTcMpL/l71N6CQAmaRcb4zyJuA==
+
+"@cbor-extract/cbor-extract-win32-x64@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.1.1.tgz#21b11a1a3f18c3e7d62fd5f87438b7ed2c64c1f7"
+  integrity sha512-2Niq1C41dCRIDeD8LddiH+mxGlO7HJ612Ll3D/E73ZWBmycued+8ghTr/Ho3CMOWPUEr08XtyBMVXAjqF+TcKw==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -1947,10 +1986,17 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@noble/secp256k1@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz"
-  integrity sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==
+"@noble/curves@^1.1.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
+  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+  dependencies:
+    "@noble/hashes" "1.3.2"
+
+"@noble/hashes@1.3.2", "@noble/hashes@^1.3.1":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
+  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -2781,11 +2827,6 @@ before-after-hook@^2.2.0:
   resolved "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz"
   integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
-big-integer@^1.6.51:
-  version "1.6.51"
-  resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz"
-  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
-
 body-parser@1.20.1:
   version "1.20.1"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
@@ -2958,6 +2999,27 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
+
+cbor-extract@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cbor-extract/-/cbor-extract-2.1.1.tgz#f154b31529fdb6b7c70fb3ca448f44eda96a1b42"
+  integrity sha512-1UX977+L+zOJHsp0mWFG13GLwO6ucKgSmSW6JTl8B9GUvACvHeIVpFqhU92299Z6PfD09aTXDell5p+lp1rUFA==
+  dependencies:
+    node-gyp-build-optional-packages "5.0.3"
+  optionalDependencies:
+    "@cbor-extract/cbor-extract-darwin-arm64" "2.1.1"
+    "@cbor-extract/cbor-extract-darwin-x64" "2.1.1"
+    "@cbor-extract/cbor-extract-linux-arm" "2.1.1"
+    "@cbor-extract/cbor-extract-linux-arm64" "2.1.1"
+    "@cbor-extract/cbor-extract-linux-x64" "2.1.1"
+    "@cbor-extract/cbor-extract-win32-x64" "2.1.1"
+
+cbor-x@^1.5.1:
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/cbor-x/-/cbor-x-1.5.4.tgz#8f0754fa8589cbd7339b613b2b5717d133508e98"
+  integrity sha512-PVKILDn+Rf6MRhhcyzGXi5eizn1i0i3F8Fe6UMMxXBnWkalq9+C5+VTmlIjAYM4iF2IYF2N+zToqAfYOp+3rfw==
+  optionalDependencies:
+    cbor-extract "^2.1.1"
 
 cborg@^1.6.0:
   version "1.9.5"
@@ -3514,6 +3576,11 @@ dot-prop@^6.0.1:
   integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
+
+dotenv@^16.0.0:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
 
 dotenv@^16.0.3:
   version "16.0.3"
@@ -4551,6 +4618,11 @@ grapheme-splitter@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz"
   integrity sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 handlebars@^4.7.7:
   version "4.7.7"
@@ -6094,6 +6166,11 @@ node-fetch@^2.6.1, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+node-gyp-build-optional-packages@5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz#92a89d400352c44ad3975010368072b41ad66c17"
+  integrity sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==
+
 node-gyp@^5.0.2:
   version "5.1.1"
   resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-5.1.1.tgz"
@@ -6365,11 +6442,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
-
-one-webcrypto@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz"
-  integrity sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==
 
 onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
@@ -6782,10 +6854,27 @@ pino-std-serializers@^6.0.0:
   resolved "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz"
   integrity sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ==
 
-pino@^8.0.0, pino@^8.11.0, pino@^8.6.1:
+pino@^8.0.0, pino@^8.11.0:
   version "8.11.0"
   resolved "https://registry.yarnpkg.com/pino/-/pino-8.11.0.tgz#2a91f454106b13e708a66c74ebc1c2ab7ab38498"
   integrity sha512-Z2eKSvlrl2rH8p5eveNUnTdd4AjJk8tAsLkHYZQKGHP4WTh2Gi1cOSOs3eWPqaj+niS3gj4UkoreoaWgF3ZWYg==
+  dependencies:
+    atomic-sleep "^1.0.0"
+    fast-redact "^3.1.1"
+    on-exit-leak-free "^2.1.0"
+    pino-abstract-transport v1.0.0
+    pino-std-serializers "^6.0.0"
+    process-warning "^2.0.0"
+    quick-format-unescaped "^4.0.3"
+    real-require "^0.2.0"
+    safe-stable-stringify "^2.3.1"
+    sonic-boom "^3.1.0"
+    thread-stream "^2.0.0"
+
+pino@^8.6.1:
+  version "8.15.0"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-8.15.0.tgz#67c61d5e397bf297e5a0433976a7f7b8aa6f876b"
+  integrity sha512-olUADJByk4twxccmAxb1RiGKOSvddHugCV3wkqjyv+3Sooa2KLrmXrKEWOKi0XPCLasRR5jBXxioE1jxUa4KzQ==
   dependencies:
     atomic-sleep "^1.0.0"
     fast-redact "^3.1.1"
@@ -8541,7 +8630,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.14.2:
-  version "3.19.1"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.19.1.tgz"
-  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
+zod@^3.21.4:
+  version "3.22.2"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.2.tgz#3add8c682b7077c05ac6f979fea6998b573e157b"
+  integrity sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==


### PR DESCRIPTION
Wanted to pull in fixes to `@atproto/crypto` in particular. Thought this would be simple, but getting import errors on that package I don't understand: seems like those symbols still exist (eg, in dist/index.js for the 0.3.0 version of the package specifically).