### PR TITLE
Enforce new operation constraints

### DIFF
--- a/packages/lib/src/data.ts
+++ b/packages/lib/src/data.ts
@@ -3,7 +3,6 @@ import { check, cidForCbor, HOUR } from '@atproto/common'
 import * as t from './types'
 import {
   assureValidCreationOp,
-  assureValidOp,
   assureValidSig,
   normalizeOp,
 } from './operations'
@@ -18,13 +17,6 @@ export const assureValidNextOp = async (
   ops: t.IndexedOperation[],
   proposed: t.CompatibleOpOrTombstone,
 ): Promise<{ nullified: CID[]; prev: CID | null }> => {
-  if (check.is(proposed, t.def.createOpV1)) {
-    const normalized = normalizeOp(proposed)
-    await assureValidOp(normalized)
-  } else {
-    await assureValidOp(proposed)
-  }
-
   // special case if account creation
   if (ops.length === 0) {
     await assureValidCreationOp(did, proposed)

--- a/packages/lib/src/types.ts
+++ b/packages/lib/src/types.ts
@@ -34,24 +34,28 @@ export type UnsignedCreateOpV1 = z.infer<typeof unsignedCreateOpV1>
 const createOpV1 = unsignedCreateOpV1.extend({ sig: z.string() })
 export type CreateOpV1 = z.infer<typeof createOpV1>
 
-const unsignedOperation = z.object({
-  type: z.literal('plc_operation'),
-  rotationKeys: z.array(z.string()),
-  verificationMethods: z.record(z.string()),
-  alsoKnownAs: z.array(z.string()),
-  services: z.record(service),
-  prev: z.string().nullable(),
-})
+const unsignedOperation = z
+  .object({
+    type: z.literal('plc_operation'),
+    rotationKeys: z.array(z.string()),
+    verificationMethods: z.record(z.string()),
+    alsoKnownAs: z.array(z.string()),
+    services: z.record(service),
+    prev: z.string().nullable(),
+  })
+  .strict()
 export type UnsignedOperation = z.infer<typeof unsignedOperation>
-const operation = unsignedOperation.extend({ sig: z.string() })
+const operation = unsignedOperation.extend({ sig: z.string() }).strict()
 export type Operation = z.infer<typeof operation>
 
-const unsignedTombstone = z.object({
-  type: z.literal('plc_tombstone'),
-  prev: z.string(),
-})
+const unsignedTombstone = z
+  .object({
+    type: z.literal('plc_tombstone'),
+    prev: z.string(),
+  })
+  .strict()
 export type UnsignedTombstone = z.infer<typeof unsignedTombstone>
-const tombstone = unsignedTombstone.extend({ sig: z.string() })
+const tombstone = unsignedTombstone.extend({ sig: z.string() }).strict()
 export type Tombstone = z.infer<typeof tombstone>
 
 const opOrTombstone = z.union([operation, tombstone])

--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -3,12 +3,24 @@ import * as plc from '@did-plc/lib'
 import { ServerError } from './error'
 import { parseDidKey } from '@atproto/crypto'
 
+const MAX_OP_BYTES = 4000
+const MAX_AKA_ENTRIES = 10
+const MAX_AKA_LENGTH = 256
+const MAX_ROTATION_ENTRIES = 10
+const MAX_SERVICE_ENTRIES = 10
+const MAX_SERVICE_TYPE_LENGTH = 256
+const MAX_SERVICE_ENDPOINT_LENGTH = 512
+const MAX_ID_LENGTH = 32
+
 export function assertValidIncomingOp(
   op: unknown,
 ): asserts op is plc.OpOrTombstone {
   const byteLength = cborEncode(op).byteLength
-  if (byteLength > 4000) {
-    throw new ServerError(400, 'Operation too large')
+  if (byteLength > MAX_OP_BYTES) {
+    throw new ServerError(
+      400,
+      `Operation too large (${MAX_OP_BYTES} bytes maximum in cbor encoding)`,
+    )
   }
   if (!check.is(op, plc.def.opOrTombstone)) {
     throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)
@@ -16,22 +28,31 @@ export function assertValidIncomingOp(
   if (op.type === 'plc_tombstone') {
     return
   }
-  if (op.alsoKnownAs.length > 10) {
-    throw new ServerError(400, 'To many alsoKnownAs items (max 10)')
+  if (op.alsoKnownAs.length > MAX_AKA_ENTRIES) {
+    throw new ServerError(
+      400,
+      `To many alsoKnownAs entries (max ${MAX_AKA_ENTRIES})`,
+    )
   }
   const akaDupe: Record<string, boolean> = {}
   for (const aka of op.alsoKnownAs) {
-    if (aka.length > 256) {
-      throw new ServerError(400, `alsoKnownAs field too long (max 256): ${aka}`)
+    if (aka.length > MAX_AKA_LENGTH) {
+      throw new ServerError(
+        400,
+        `alsoKnownAs entry too long (max ${MAX_AKA_LENGTH}): ${aka}`,
+      )
     }
     if (akaDupe[aka]) {
-      throw new ServerError(400, `duplicate alsoKnownAs field: ${aka}`)
+      throw new ServerError(400, `duplicate alsoKnownAs entry: ${aka}`)
     } else {
       akaDupe[aka] = true
     }
   }
-  if (op.rotationKeys.length > 5) {
-    throw new ServerError(400, 'To many rotationKey items (max 5)')
+  if (op.rotationKeys.length > MAX_ROTATION_ENTRIES) {
+    throw new ServerError(
+      400,
+      `Too many rotationKey entries (max ${MAX_ROTATION_ENTRIES})`,
+    )
   }
   for (const key of op.rotationKeys) {
     try {
@@ -41,26 +62,38 @@ export function assertValidIncomingOp(
     }
   }
   const serviceEntries = Object.entries(op.services)
-  if (serviceEntries.length > 10) {
-    throw new ServerError(400, 'To many service entries (max 10)')
+  if (serviceEntries.length > MAX_SERVICE_ENTRIES) {
+    throw new ServerError(
+      400,
+      `To many service entries (max ${MAX_SERVICE_ENTRIES})`,
+    )
   }
   for (const [id, service] of serviceEntries) {
-    if (id.length > 32) {
-      throw new ServerError(400, `Service id too long (max 32): ${id}`)
+    if (id.length > MAX_ID_LENGTH) {
+      throw new ServerError(
+        400,
+        `Service id too long (max ${MAX_ID_LENGTH}): ${id}`,
+      )
     }
-    if (service.type.length > 256) {
-      throw new ServerError(400, 'Service type too long (max 256)')
+    if (service.type.length > MAX_SERVICE_TYPE_LENGTH) {
+      throw new ServerError(
+        400,
+        `Service type too long (max ${MAX_SERVICE_TYPE_LENGTH})`,
+      )
     }
-    if (service.endpoint.length > 512) {
-      throw new ServerError(400, 'Service endpoint too long (max 512)')
+    if (service.endpoint.length > MAX_SERVICE_ENDPOINT_LENGTH) {
+      throw new ServerError(
+        400,
+        `Service endpoint too long (max ${MAX_SERVICE_ENDPOINT_LENGTH})`,
+      )
     }
   }
   const verifyMethods = Object.entries(op.verificationMethods)
   for (const [id, key] of verifyMethods) {
-    if (id.length > 32) {
+    if (id.length > MAX_ID_LENGTH) {
       throw new ServerError(
         400,
-        `Verification Method id too long (max 32): ${id}`,
+        `Verification Method id too long (max ${MAX_ID_LENGTH}): ${id}`,
       )
     }
     try {

--- a/packages/server/src/constraints.ts
+++ b/packages/server/src/constraints.ts
@@ -1,0 +1,72 @@
+import { cborEncode, check } from '@atproto/common'
+import * as plc from '@did-plc/lib'
+import { ServerError } from './error'
+import { parseDidKey } from '@atproto/crypto'
+
+export function assertValidIncomingOp(
+  op: unknown,
+): asserts op is plc.OpOrTombstone {
+  const byteLength = cborEncode(op).byteLength
+  if (byteLength > 4000) {
+    throw new ServerError(400, 'Operation too large')
+  }
+  if (!check.is(op, plc.def.opOrTombstone)) {
+    throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)
+  }
+  if (op.type === 'plc_tombstone') {
+    return
+  }
+  if (op.alsoKnownAs.length > 10) {
+    throw new ServerError(400, 'To many alsoKnownAs items (max 10)')
+  }
+  const akaDupe: Record<string, boolean> = {}
+  for (const aka of op.alsoKnownAs) {
+    if (aka.length > 256) {
+      throw new ServerError(400, `alsoKnownAs field too long (max 256): ${aka}`)
+    }
+    if (akaDupe[aka]) {
+      throw new ServerError(400, `duplicate alsoKnownAs field: ${aka}`)
+    } else {
+      akaDupe[aka] = true
+    }
+  }
+  if (op.rotationKeys.length > 5) {
+    throw new ServerError(400, 'To many rotationKey items (max 5)')
+  }
+  for (const key of op.rotationKeys) {
+    try {
+      parseDidKey(key)
+    } catch (err) {
+      throw new ServerError(400, `Invalid rotationKey: ${key}`)
+    }
+  }
+  const serviceEntries = Object.entries(op.services)
+  if (serviceEntries.length > 10) {
+    throw new ServerError(400, 'To many service entries (max 10)')
+  }
+  for (const [id, service] of serviceEntries) {
+    if (id.length > 32) {
+      throw new ServerError(400, `Service id too long (max 32): ${id}`)
+    }
+    if (service.type.length > 256) {
+      throw new ServerError(400, 'Service type too long (max 256)')
+    }
+    if (service.endpoint.length > 512) {
+      throw new ServerError(400, 'Service endpoint too long (max 512)')
+    }
+  }
+  const verifyMethods = Object.entries(op.verificationMethods)
+  for (const [id, key] of verifyMethods) {
+    if (id.length > 32) {
+      throw new ServerError(
+        400,
+        `Verification Method id too long (max 32): ${id}`,
+      )
+    }
+    try {
+      parseDidKey(key)
+    } catch (err) {
+      throw new ServerError(400, `Invalid verificationMethod key: ${key}`)
+    }
+  }
+}

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -139,9 +139,15 @@ export function assertValidIncomingOp(
   if (op.alsoKnownAs.length > 10) {
     throw new ServerError(400, 'To many alsoKnownAs items (max 10)')
   }
+  const akaDupe: Record<string, boolean> = {}
   for (const aka of op.alsoKnownAs) {
     if (aka.length > 256) {
       throw new ServerError(400, `alsoKnownAs field too long (max 256): ${aka}`)
+    }
+    if (akaDupe[aka]) {
+      throw new ServerError(400, `duplicate alsoKnownAs field: ${aka}`)
+    } else {
+      akaDupe[aka] = true
     }
   }
   if (op.rotationKeys.length > 5) {

--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -1,9 +1,8 @@
 import express from 'express'
-import { cborEncode, check } from '@atproto/common'
 import * as plc from '@did-plc/lib'
 import { ServerError } from './error'
 import { AppContext } from './context'
-import { parseDidKey } from '@atproto/crypto'
+import { assertValidIncomingOp } from './constraints'
 
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
@@ -121,74 +120,6 @@ export const createRouter = (ctx: AppContext): express.Router => {
   })
 
   return router
-}
-
-export function assertValidIncomingOp(
-  op: unknown,
-): asserts op is plc.OpOrTombstone {
-  const byteLength = cborEncode(op).byteLength
-  if (byteLength > 4000) {
-    throw new ServerError(400, 'Operation too large')
-  }
-  if (!check.is(op, plc.def.opOrTombstone)) {
-    throw new ServerError(400, `Not a valid operation: ${JSON.stringify(op)}`)
-  }
-  if (op.type === 'plc_tombstone') {
-    return
-  }
-  if (op.alsoKnownAs.length > 10) {
-    throw new ServerError(400, 'To many alsoKnownAs items (max 10)')
-  }
-  const akaDupe: Record<string, boolean> = {}
-  for (const aka of op.alsoKnownAs) {
-    if (aka.length > 256) {
-      throw new ServerError(400, `alsoKnownAs field too long (max 256): ${aka}`)
-    }
-    if (akaDupe[aka]) {
-      throw new ServerError(400, `duplicate alsoKnownAs field: ${aka}`)
-    } else {
-      akaDupe[aka] = true
-    }
-  }
-  if (op.rotationKeys.length > 5) {
-    throw new ServerError(400, 'To many rotationKey items (max 5)')
-  }
-  for (const key of op.rotationKeys) {
-    try {
-      parseDidKey(key)
-    } catch (err) {
-      throw new ServerError(400, `Invalid rotationKey: ${key}`)
-    }
-  }
-  const serviceEntries = Object.entries(op.services)
-  if (serviceEntries.length > 10) {
-    throw new ServerError(400, 'To many service entries (max 10)')
-  }
-  for (const [id, service] of serviceEntries) {
-    if (id.length > 32) {
-      throw new ServerError(400, `Service id too long (max 32): ${id}`)
-    }
-    if (service.type.length > 256) {
-      throw new ServerError(400, 'Service type too long (max 256)')
-    }
-    if (service.endpoint.length > 512) {
-      throw new ServerError(400, 'Service endpoint too long (max 512)')
-    }
-  }
-  const verifyMethods = Object.entries(op.verificationMethods)
-  for (const [id, key] of verifyMethods) {
-    if (id.length > 32) {
-      throw new ServerError(
-        400,
-        `Verification Method id too long (max 32): ${id}`,
-      )
-    }
-    try {
-      parseDidKey(key)
-    } catch (err) {
-      throw new ServerError(400, `Invalid verificationMethod key: ${key}`)
-    }
-  }
 }
 
 export default createRouter

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -220,7 +220,7 @@ describe('PLC server', () => {
     }
   })
 
-  it('still allows create v1s', async () => {
+  it('disallows create v1s', async () => {
     const createV1 = await plc.deprecatedSignCreate(
       {
         type: 'create',
@@ -233,7 +233,8 @@ describe('PLC server', () => {
       signingKey,
     )
     const did = await didForCreateOp(createV1)
-    await client.sendOperation(did, createV1 as any)
+    const attempt = client.sendOperation(did, createV1 as any)
+    await expect(attempt).rejects.toThrow()
   })
 
   it('healthcheck succeeds when database is available.', async () => {


### PR DESCRIPTION
Enforce some constraints on incoming operations:

Rate limit:
- rate limit incoming accepted operations
- We do this naively off of indexed operation in the database, so that we can maintain a separate focus on service abuse based on IP
- _Do not_ enforce operations rate limits during recovery operations. Else this could be abused by a bad actor to DDOS further PLC updates
- enforce following limits
  - 10 ops/hr
  - 30 ops/day
  - 100 ops/wk

Formatting:
- drop allowed op size from 7.5 kb -> 4 kb
- enforce strict schema validation (no unspecced fields)
- no longer accept v1 create operations
- max 10 length on each DID field (alsoKnownAs, verificationMethods, services)
- max 5 length on rotationKeys (this is a hold over from prev limit, but we can raise if we like)
- enforce string lengths on all fields
- enforce unique alsoKnownAs
- enforce supported key types (p256/k256) on all rotationKeys & signingKeys (this was enforced before, but the logic was relocated)