### PR TITLE
Fix boolean type in openapi definition

### DIFF
--- a/website/spec/plc-server-openapi3.yaml
+++ b/website/spec/plc-server-openapi3.yaml
@@ -373,7 +373,7 @@ components:
           type: cid
           description: "Hash of the operation, in string CID format"
         nullified:
-          type: bool
+          type: boolean
           description: "Whether this operation is included in the current operation chain, or has been overridden"
         createdAt:
           type: string


### PR DESCRIPTION
`bool` is apparently not a thing in open api.  Should be `boolean`.