### PR TITLE
Clarify which op the clobbering time constraint is against

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The PLC server provides a 72hr window during which a higher authority rotation k
 To do so, that key must sign a new operation that points to the CID of the last "valid" operation - ie the fork point.
 The PLC server will accept this recovery operation as long as:
 
-- it is submitted within 72hrs of the referenced operation
+- it is submitted within 72hrs of the to-be-invalidated operation
 - the key used for the signature has a lower index in the `rotationKeys` array than the key that signed the to-be-invalidated operation
 
 


### PR DESCRIPTION
it's not clear to me which operation is referred to by "the referenced operation"

since operations literally refer to a `prev` operation, the wording here could imply that you can only clobber an op if its *parent* (the fork point) was submitted within 72h, which would be surprising to me.

this change uses the `to-be-invalided operation` phrasing used in the other condition to make it clear that the deadline is checked against the operation that will be clobbered. (should it say "*first* to-be-invalidated op"?)

(related test-case update: https://github.com/did-method-plc/go-didplc/pull/15 )