### PR TITLE
Validate `after` parameter to avoid HTTP 500 response

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -31,6 +31,9 @@ export const createRouter = (ctx: AppContext): express.Router => {
     }
     const count = Math.min(parsedCount, 1000)
     const after = req.query.after ? new Date(req.query.after) : undefined
+    if (after !== undefined && isNaN(after.getTime())) {
+      throw new ServerError(400, 'Invalid after parameter')
+    }
     const ops = await ctx.db.exportOps(count, after)
     res.setHeader('content-type', 'application/jsonlines')
     res.status(200)


### PR DESCRIPTION
Return 400 bad-request calling out the `after` param instead of a generic HTTP 500 (and a pointless query to the database) for `/export`.

i tried to make this consistent with the `count` validation in the same route.

example HTTP 500: https://plc.directory/export?after=foo

less-obvious 500: https://plc.directory/export?after=2023-03-01T20:09:48.393+00:00