### PR TITLE
Bulk DID document endpoint

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -47,6 +47,7 @@
     "kysely": "^0.23.4",
     "multiformats": "^9.6.4",
     "pg": "^8.9.0",
+    "pg-cursor": "^2.16.1",
     "pino": "^8.11.0",
     "pino-http": "^8.3.3",
     "ws": "^8.18.3"
@@ -54,6 +55,7 @@
   "devDependencies": {
     "@types/express": "^5.0.5",
     "@types/pg": "^8.6.5",
+    "@types/pg-cursor": "^2.7.2",
     "@types/ws": "^8.18.1",
     "eslint-plugin-prettier": "^4.2.1"
   }

--- a/packages/server/src/db/index.ts
+++ b/packages/server/src/db/index.ts
@@ -1,5 +1,6 @@
 import { Kysely, Migrator, PostgresDialect, sql } from 'kysely'
 import { Pool as PgPool, types as pgTypes } from 'pg'
+import Cursor from 'pg-cursor'
 import { CID } from 'multiformats/cid'
 import { cidForCbor } from '@atproto/common'
 import * as plc from '@did-plc/lib'
@@ -52,7 +53,7 @@ export class Database implements PlcDatabase {
     }
 
     const db = new Kysely<DatabaseSchema>({
-      dialect: new PostgresDialect({ pool }),
+      dialect: new PostgresDialect({ pool, cursor: Cursor }),
     })
 
     return new Database(db, schema)

--- a/packages/server/src/db/mock.ts
+++ b/packages/server/src/db/mock.ts
@@ -76,6 +76,17 @@ export class MockDatabase implements PlcDatabase {
     return op.operation
   }
 
+  async *streamLastOpsForDids(
+    dids: string[],
+  ): AsyncGenerator<{ did: string; operation: plc.CompatibleOpOrTombstone }> {
+    for (const did of dids) {
+      const op = await this.lastOpForDid(did)
+      if (op) {
+        yield { did, operation: op }
+      }
+    }
+  }
+
   // disabled in mocks
   async exportOps(_count: number, _after?: Date): Promise<plc.ExportedOp[]> {
     return []

--- a/packages/server/src/db/types.ts
+++ b/packages/server/src/db/types.ts
@@ -15,6 +15,9 @@ export interface PlcDatabase {
     includeNull?: boolean,
   ): Promise<plc.IndexedOperation[]>
   lastOpForDid(did: string): Promise<plc.CompatibleOpOrTombstone | null>
+  streamLastOpsForDids(
+    dids: string[],
+  ): AsyncGenerator<{ did: string; operation: plc.CompatibleOpOrTombstone }>
   exportOps(count: number, after?: Date): Promise<plc.ExportedOp[]>
   exportOpsSeq(count: number, after: number): Promise<plc.ExportedOpWithSeq[]>
   removeInvalidOps(

--- a/website/spec/plc-server-openapi3.yaml
+++ b/website/spec/plc-server-openapi3.yaml
@@ -182,6 +182,59 @@ paths:
                 $ref: '#/components/schemas/LogEntry'
         '400':
           $ref: '#/components/responses/400BadRequest'
+  /dids:
+    post:
+      description: "Bulk lookup of multiple DID documents in a single request, in JSON Lines format"
+      operationId: BulkLookupDids
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - dids
+              properties:
+                dids:
+                  type: array
+                  items:
+                    type: string
+                  minItems: 1
+                  maxItems: 1000
+                  description: "Array of DID identifiers to look up"
+              example:
+                dids:
+                  - "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+                  - "did:plc:z72i7hdynmk6r22z27h6tvur"
+      responses:
+        '200':
+          description: "Success, returned DID documents"
+          content:
+            application/jsonlines:
+              description: "Newline-delimited JSON, with one result object per line for each requested DID"
+              schema:
+                $ref: '#/components/schemas/BulkLookupResult'
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+      x-codeSamples:
+        - lang: Shell
+          label: curl
+          source: |
+            curl -s -X POST https://plc.directory/dids \
+              -H "Content-Type: application/json" \
+              -d '{"dids":["did:plc:ewvi7nxzyoun6zhxrhs64oiz","did:plc:z72i7hdynmk6r22z27h6tvur"]}'
+        - lang: Python
+          label: Python
+          source: |
+            import requests
+
+            resp = requests.post(
+                "https://plc.directory/dids",
+                json={"dids": ["did:plc:ewvi7nxzyoun6zhxrhs64oiz", "did:plc:z72i7hdynmk6r22z27h6tvur"]}
+            )
+            resp.raise_for_status()
+            for line in resp.text.strip().split("\n"):
+                print(line)
 
 components:
   responses:
@@ -454,5 +507,41 @@ components:
                 type: string
             example:
               id: "#atproto_pds"
+              type: "AtprotoPersonalDataServer"
+              serviceEndpoint: "https://bsky.social"
+
+    BulkLookupResult:
+      type: object
+      required:
+        - did
+        - document
+      properties:
+        did:
+          type: string
+          description: "The DID that was looked up"
+        document:
+          oneOf:
+            - $ref: '#/components/schemas/DidDocument'
+            - type: "null"
+          description: "The resolved DID document, or null if not found/tombstoned"
+        notFound:
+          type: boolean
+          description: "True if the DID was not found in the directory"
+        tombstoned:
+          type: boolean
+          description: "True if the DID has been tombstoned (deactivated)"
+      example:
+        did: "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+        document:
+          id: "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+          alsoKnownAs:
+            - "at://atproto.com"
+          verificationMethod:
+            - id: "did:plc:ewvi7nxzyoun6zhxrhs64oiz#atproto"
+              type: "Multikey"
+              controller: "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+              publicKeyMultibase: "zQ3shXjHeiBuRCKmM36cuYnm7YEMzhGnCmCyW92sRJ9pribSF"
+          service:
+            - id: "#atproto_pds"
               type: "AtprotoPersonalDataServer"
               serviceEndpoint: "https://bsky.social"

--- a/website/spec/v0.1/did-plc.md
+++ b/website/spec/v0.1/did-plc.md
@@ -259,6 +259,37 @@ NOTE: If the `after` query parameter is not set, the response format defaults to
 
 NOTE: Legacy responses order operations by `createdAt`, while non-legacy responses order operations by `seq`. These orders may be slightly different! In either case, operations for a particular DID will always be in the same order relative to each other. In other words, if you isolated the operations for a single DID, the `seq` order and the `createdAt` orders are identical.
 
+### Bulk DID Lookup
+
+The HTTP endpoint `https://plc.directory/dids` allows bulk lookup of DID documents in a single request, reducing HTTP overhead when revalidating many DIDs.
+
+**Request:**
+- Method: `POST`
+- Content-Type: `application/json`
+- Body: `{ "dids": ["did:plc:abc...", "did:plc:xyz..."] }`
+- Maximum of 1,000 DIDs per request
+
+**Response:**
+- Content-Type: `application/jsonlines`
+- Each line is a JSON object with the following fields:
+  - `did` (string): The requested DID identifier
+  - `document` (object or null): The resolved DID document, or `null` if not found or tombstoned
+  - `notFound` (boolean, optional): Present and `true` if the DID was not found in the directory
+  - `tombstoned` (boolean, optional): Present and `true` if the DID has been deactivated
+
+Example request:
+```bash
+curl -X POST https://plc.directory/dids \
+  -H "Content-Type: application/json" \
+  -d '{"dids":["did:plc:ewvi7nxzyoun6zhxrhs64oiz","did:plc:z72i7hdynmk6r22z27h6tvur"]}'
+```
+
+Example response:
+```jsonl
+{"did":"did:plc:ewvi7nxzyoun6zhxrhs64oiz","document":{"@context":[...],"id":"did:plc:ewvi7nxzyoun6zhxrhs64oiz",...}}
+{"did":"did:plc:z72i7hdynmk6r22z27h6tvur","document":null,"notFound":true}
+```
+
 ### Export Streaming WebSocket
 
 The [WebSocket](https://datatracker.ietf.org/doc/html/rfc6455) endpoint at `wss://plc.directory/export/stream` returns a stream of JSON objects in the same format as the (non-legacy) `/export` endpoint. JSON objects are delimited by the WebSocket message framing layer (*not* newlines).
@@ -454,6 +485,10 @@ A "DID PLC history explorer" web interface would make the public nature of the D
 It is conceivable that longer DID PLCs, with more of the SHA-256 characters, will be supported in the future. It is also conceivable that a different hash algorithm would be allowed. Any such changes would allow existing DIDs in their existing syntax to continue being used.
 
 ## Changelog
+
+### 2026-01-20 (vn.e.x.t)
+
+- Introduces `POST /dids` endpoint for bulk DID document lookup
 
 ### 2025-12-04 (v0.3.0)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2382,6 +2382,23 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/pg-cursor@^2.7.2":
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/@types/pg-cursor/-/pg-cursor-2.7.2.tgz#0b1f80685a48940d48c742c48c10f9a923290e76"
+  integrity sha512-m3xT8bVFCvx98LuzbvXyuCdT/Hjdd/v8ml4jL4K1QF70Y8clOfCFdgoaEB1FWdcSwcpoFYZTJQaMD9/GQ27efQ==
+  dependencies:
+    "@types/node" "*"
+    "@types/pg" "*"
+
+"@types/pg@*":
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-8.16.0.tgz#b7af0d642752340b7c9de1c33afd9bc5c5f0ebeb"
+  integrity sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==
+  dependencies:
+    "@types/node" "*"
+    pg-protocol "*"
+    pg-types "^2.2.0"
+
 "@types/pg@^8.6.5":
   version "8.6.5"
   resolved "https://registry.npmjs.org/@types/pg/-/pg-8.6.5.tgz"
@@ -6809,6 +6826,11 @@ pg-connection-string@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
+
+pg-cursor@^2.16.1:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/pg-cursor/-/pg-cursor-2.16.2.tgz#a1bc870403303a9436932c0d6a4c27b05abbb287"
+  integrity sha512-OzGiSg/71d6h3ls//WRBLaCj3hMHBOuAqCNe8FvU4poZu36hR7y4ZKFVu+JfFIEAVr6CibHai5lg53QJlYZAJw==
 
 pg-int8@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes #113.

This introduces a `POST /dids` endpoint that accepts a bulk list of DIDs and returns their documents as JSONL. I chose a limit of 1,000 DIDs per request because it feels like a good balance between request/response size handling and memory usage.

Results are yielded from the database using `Kysely.stream()` which requires the `pg-cursor` package to facilitate streaming from PostgreSQL. Yielding minimises memory usage even with 1,000 DID documents being returned.

The docs and OpenAI spec have been updated with usage instructions.

Example usage:

```shell
curl -X POST http://localhost:2582/dids \
  -H "Content-Type: application/json" \
  -d '{"dids":["did:plc:l2phgxysbc76ywfuodn5h2n3","did:plc:hhc7r3vtu5i4n5s6demzdjur"]}'
```