### PR TITLE
remove axios

### DIFF
--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -34,7 +34,6 @@
     "@atproto/common": "0.3.0",
     "@atproto/crypto": "0.4.3",
     "@ipld/dag-cbor": "^7.0.3",
-    "axios": "^1.3.4",
     "multiformats": "^9.6.4",
     "uint8arrays": "3.0.0",
     "zod": "^3.21.4"

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -1,6 +1,5 @@
 import { check, cidForCbor } from '@atproto/common'
 import { Keypair } from '@atproto/crypto'
-import axios, { AxiosError } from 'axios'
 import {
   atprotoOp,
   createUpdateOp,
@@ -17,15 +16,12 @@ export class Client {
   constructor(public url: string) {}
 
   private async makeGetReq(url: string) {
-    try {
-      const res = await axios.get(url)
-      return res.data
-    } catch (err) {
-      if (!axios.isAxiosError(err)) {
-        throw err
-      }
-      throw PlcClientError.fromAxiosError(err)
-    }
+    const res = await fetch(url)
+    if (!res.ok) {
+      const data = await res.json().catch(() => undefined)
+      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
+     }
+     return res.json()
   }
 
   async getDocument(did: string): Promise<t.DidDocument> {
@@ -57,14 +53,14 @@ export class Client {
   }
 
   async sendOperation(did: string, op: t.OpOrTombstone) {
-    try {
-      await axios.post(this.postOpUrl(did), op)
-    } catch (err) {
-      if (!axios.isAxiosError(err)) {
-        throw err
-      }
-      throw PlcClientError.fromAxiosError(err)
-    }
+    const res = await fetch(this.postOpUrl(did), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(op),
+    })
+    if (!res.ok) {
+      const data = await res.json().catch(() => undefined)
+      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
   }
 
   async export(after?: number, count?: number): Promise<t.ExportedOpWithSeq[]> {
@@ -73,8 +69,13 @@ export class Client {
     if (count !== undefined) {
       url.searchParams.append('count', count.toString(10))
     }
-    const res = await axios.get(url.toString())
-    const lines = res.data.split('\n')
+    const res = await fetch(url.toString())
+    if (!res.ok) {
+      const data = await res.text().catch(() => undefined)
+      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
+    }
+    const text = await res.text()
+    const lines = text.split('\n').filter(Boolean)
     return lines.map((l) => JSON.parse(l))
   }
 
@@ -152,14 +153,6 @@ export class PlcClientError extends Error {
     public message: string,
   ) {
     super(message)
-  }
-
-  static fromAxiosError(err: AxiosError) {
-    return new PlcClientError(
-      err.response?.status || 500,
-      err.response?.data,
-      err.message,
-    )
   }
 }
 

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -19,7 +19,7 @@ export class Client {
     const res = await fetch(url)
     if (!res.ok) {
       const data = await res.json().catch(() => undefined)
-      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
+      throw new PlcClientError(res.status, data, `HTTP error ${res.status}`)
      }
      return res.json()
   }
@@ -60,7 +60,7 @@ export class Client {
     })
     if (!res.ok) {
       const data = await res.json().catch(() => undefined)
-      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
+      throw new PlcClientError(res.status, data, `HTTP error ${res.status}`)
   }
 
   async export(after?: number, count?: number): Promise<t.ExportedOpWithSeq[]> {
@@ -72,7 +72,7 @@ export class Client {
     const res = await fetch(url.toString())
     if (!res.ok) {
       const data = await res.text().catch(() => undefined)
-      throw new PlcClientError(res.status, data, 'HTTP error ${res.status}')
+      throw new PlcClientError(res.status, data, `HTTP error ${res.status}`)
     }
     const text = await res.text()
     const lines = text.split('\n').filter(Boolean)

--- a/packages/lib/src/client.ts
+++ b/packages/lib/src/client.ts
@@ -20,8 +20,8 @@ export class Client {
     if (!res.ok) {
       const data = await res.json().catch(() => undefined)
       throw new PlcClientError(res.status, data, `HTTP error ${res.status}`)
-     }
-     return res.json()
+    }
+    return res.json()
   }
 
   async getDocument(did: string): Promise<t.DidDocument> {
@@ -61,6 +61,7 @@ export class Client {
     if (!res.ok) {
       const data = await res.json().catch(() => undefined)
       throw new PlcClientError(res.status, data, `HTTP error ${res.status}`)
+    }
   }
 
   async export(after?: number, count?: number): Promise<t.ExportedOpWithSeq[]> {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,7 +39,6 @@
     "@atproto/common": "0.3.0",
     "@atproto/crypto": "0.4.3",
     "@did-plc/lib": "*",
-    "axios": "^1.3.4",
     "cors": "^2.8.5",
     "dotenv": "^16.0.0",
     "express": "^4.18.2",

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -285,7 +285,10 @@ describe('PLC server', () => {
   it('exports the data set', async () => {
     const res = await fetch(`${client.url}/export`) // "legacy" non-sequenced export
     if (!res.ok) throw new Error(`HTTP error ${res.status}`)
-    const data = (await res.text()).split('\n').filter(Boolean).map((l) => JSON.parse(l))
+    const data = (await res.text())
+      .split('\n')
+      .filter(Boolean)
+      .map((l) => JSON.parse(l))
     expect(data.every((row) => check.is(row, plc.def.exportedOp))).toBeTruthy()
     expect(data.length).toEqual(32)
     for (let i = 1; i < data.length; i++) {

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -285,7 +285,7 @@ describe('PLC server', () => {
   it('exports the data set', async () => {
     const res = await fetch(`${client.url}/export`) // "legacy" non-sequenced export
     if (!res.ok) throw new Error(`HTTP error ${res.status}`)
-    const data = (await res.text()).split('\n').filter(Boolean).map(JSON.parse)
+    const data = (await res.text()).split('\n').filter(Boolean).map((l) => JSON.parse(l))
     expect(data.every((row) => check.is(row, plc.def.exportedOp))).toBeTruthy()
     expect(data.length).toEqual(32)
     for (let i = 1; i < data.length; i++) {

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -1,4 +1,3 @@
-import axios, { AxiosError } from 'axios'
 import { P256Keypair } from '@atproto/crypto'
 import * as plc from '@did-plc/lib'
 import { CloseFn, runTestServer, TEST_ADMIN_SECRET } from './_util'
@@ -284,8 +283,9 @@ describe('PLC server', () => {
   })
 
   it('exports the data set', async () => {
-    const res = await axios.get(`${client.url}/export`) // "legacy" non-sequenced export
-    const data = res.data.split('\n').map(JSON.parse)
+    const res = await fetch(`${client.url}/export`) // "legacy" non-sequenced export
+    if (!res.ok) throw new Error(`HTTP error ${res.status}`)
+    const data = (await res.text()).split('\n').filter(Boolean).map(JSON.parse)
     expect(data.every((row) => check.is(row, plc.def.exportedOp))).toBeTruthy()
     expect(data.length).toEqual(32)
     for (let i = 1; i < data.length; i++) {
@@ -341,12 +341,22 @@ describe('PLC server', () => {
 
   it('disallows removal of valid operations.', async () => {
     const auditLog = await client.getAuditableLog(did1)
-    const promise = axios.post(`${client.url}/admin/removeInvalidOps`, {
-      adminSecret: TEST_ADMIN_SECRET,
-      did: did1,
-      cid: auditLog[0].cid,
-    })
-    await expect(promise).rejects.toThrow(AxiosError)
+    const promise = (async () => {
+      const r = await fetch(`${client.url}/admin/removeInvalidOps`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          adminSecret: TEST_ADMIN_SECRET,
+          did: did1,
+          cid: auditLog[0].cid,
+        }),
+      })
+      if (!r.ok) {
+        const data = await r.json().catch(() => undefined)
+        throw new PlcClientError(r.status, data, `HTTP error ${r.status}`)
+      }
+    })()
+    await expect(promise).rejects.toThrow(PlcClientError)
   })
 
   it('allows invalid operations to be removed using adminSecret', async () => {
@@ -378,13 +388,17 @@ describe('PLC server', () => {
       .execute()
 
     // attempt removal
-    const removedOps = (
-      await axios.post(`${client.url}/admin/removeInvalidOps`, {
+    const removeRes = await fetch(`${client.url}/admin/removeInvalidOps`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
         adminSecret: TEST_ADMIN_SECRET,
         did: did,
         cid: res.cid,
-      })
-    ).data
+      }),
+    })
+    if (!removeRes.ok) throw new Error(`HTTP error ${removeRes.status}`)
+    const removedOps = await removeRes.json()
     expect(removedOps).toEqual([res.operation]) // should return the removed op
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2908,15 +2908,6 @@ aws4@^1.8.0:
   resolved "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
-axios@^1.3.4:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.3.4.tgz#f5760cefd9cfb51fd2481acf88c05f67c4523024"
-  integrity sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==
-  dependencies:
-    follow-redirects "^1.15.0"
-    form-data "^4.0.0"
-    proxy-from-env "^1.1.0"
-
 babel-eslint@^10.1.0:
   version "10.1.0"
   resolved "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz"
@@ -3392,7 +3383,7 @@ columnify@^1.5.4:
     strip-ansi "^6.0.1"
     wcwidth "^1.0.0"
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -4558,24 +4549,10 @@ flatted@^3.1.0:
   resolved "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-follow-redirects@^1.15.0:
-  version "1.15.2"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz"
-  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
-
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
   integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
-form-data@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz"
-  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -7278,11 +7255,6 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.28:
   version "1.9.0"


### PR DESCRIPTION
Removes `axios` from `packages/lib` and `packages/server`, replacing all calls with the native `fetch` API. 

Motivation: https://socket.dev/blog/axios-npm-package-compromised