### PR TITLE
Apply backpressure to slow /export/stream consumers

### DIFF
--- a/packages/server/src/routes.ts
+++ b/packages/server/src/routes.ts
@@ -1,12 +1,18 @@
-import { CID } from 'multiformats/cid'
+import { pipeline } from 'node:stream/promises'
 import express from 'express'
-import { WebSocket } from 'ws'
+import { WebSocket, createWebSocketStream } from 'ws'
 import * as plc from '@did-plc/lib'
 import { ServerError } from './error'
 import { AppContext } from './context'
 import { assertValidIncomingOp } from './constraints'
-import { timingSafeStringEqual } from './util'
+import { stringify, timingSafeStringEqual } from './util'
 import { Outbox, OutboxError } from './sequencer'
+
+// Once a websocket has this much data buffered, we wait for it to flush
+// before sending more events. Slow consumers then apply backpressure into
+// the outbox, which closes them if they fall too far behind — rather than
+// buffering events in process memory without bound.
+const MAX_WS_BUFFERED_BYTES = 256 * 1024
 
 export const createRouter = (ctx: AppContext): express.Router => {
   const router = express.Router()
@@ -96,33 +102,33 @@ export const createRouter = (ctx: AppContext): express.Router => {
           abortController.abort()
         })
 
-        ws.on('error', (err) => {
-          req.log.error({ err }, 'websocket error')
-          abortController.abort()
+        // Note: each event is sent in a separate websocket message.
+        // OutboxErrors (stale cursor, consumer too slow) close the socket
+        // gracefully with a reason, rather than erroring the pipeline, which
+        // would abruptly terminate the socket without a close frame.
+        async function* outboxEvents() {
+          try {
+            yield* outbox.events(cursor, abortController.signal)
+          } catch (err) {
+            if (err instanceof OutboxError) {
+              ws.close(1000, err.message)
+              return
+            }
+            throw err
+          }
+        }
+
+        // decodeStrings: false so events are sent as text frames, not binary
+        const websocket = createWebSocketStream(ws, {
+          decodeStrings: false,
+          writableHighWaterMark: MAX_WS_BUFFERED_BYTES,
         })
 
         try {
-          for await (const evt of outbox.events(
-            cursor,
-            abortController.signal,
-          )) {
-            if (ws.readyState !== WebSocket.OPEN) {
-              break
-            }
-            // Note: each event is sent in a separate websocket message
-            ws.send(JSON.stringify(evt))
-          }
+          await pipeline(outboxEvents(), stringify, websocket)
         } catch (err) {
-          if (err instanceof OutboxError) {
-            // consumer too slow, or stale cursor
-            ws.close(1000, err.message)
-          }
           if (!abortController.signal.aborted) {
             req.log.error({ err }, 'error streaming events')
-          }
-        } finally {
-          if (ws.readyState === WebSocket.OPEN) {
-            ws.close()
           }
         }
       },

--- a/packages/server/src/util.ts
+++ b/packages/server/src/util.ts
@@ -17,3 +17,11 @@ export const timingSafeStringEqual = (a: string, b: string): boolean => {
 
   return timingSafeEqual(bufA, bufB)
 }
+
+export async function* stringify(
+  iterable: AsyncIterable<unknown>,
+): AsyncIterable<string> {
+  for await (const item of iterable) {
+    yield JSON.stringify(item)
+  }
+}

--- a/packages/server/tests/export-stream.test.ts
+++ b/packages/server/tests/export-stream.test.ts
@@ -287,13 +287,48 @@ describe('/export/stream endpoint', () => {
 
   it('rejects cursors from the future', async () => {
     const ws = new WebSocket(`${wsUrl}?cursor=99999999`)
-    const closeReason = await new Promise<string>((resolve, reject) => {
-      ws.on('error', reject)
-      ws.on('close', (code, reason) => {
-        resolve(reason.toString())
-      })
-      setTimeout(reject, 1000)
-    })
+    const [closeCode, closeReason] = await new Promise<[number, string]>(
+      (resolve, reject) => {
+        ws.on('error', reject)
+        ws.on('close', (code, reason) => {
+          resolve([code, reason.toString()])
+        })
+        setTimeout(reject, 1000)
+      },
+    )
+    expect(closeCode).toBe(1000)
     expect(closeReason).toBe(CloseReason.FutureCursor)
+  })
+
+  it('rejects outdated cursors', async () => {
+    const did = await createDid(client)
+    await waitForSequencing()
+
+    // Backdate this operation beyond the one-week backfill window, so that a
+    // cursor pointing just before it is considered outdated
+    const eightDaysAgo = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000)
+    await db.db
+      .updateTable('operations')
+      .set({ createdAt: eightDaysAgo })
+      .where('did', '=', did)
+      .execute()
+    const { seq } = await db.db
+      .selectFrom('operations')
+      .select('seq')
+      .where('did', '=', did)
+      .executeTakeFirstOrThrow()
+
+    const ws = new WebSocket(`${wsUrl}?cursor=${(seq as number) - 1}`)
+    const [closeCode, closeReason] = await new Promise<[number, string]>(
+      (resolve, reject) => {
+        ws.on('error', reject)
+        ws.on('close', (code, reason) => {
+          resolve([code, reason.toString()])
+        })
+        setTimeout(reject, 1000)
+      },
+    )
+    expect(closeCode).toBe(1000)
+    expect(closeReason).toBe(CloseReason.OutdatedCursor)
   })
 })


### PR DESCRIPTION
Previously, events streamed over `/export/stream` were written to the websocket without regard for whether the client was keeping up.

Now the server pauses streaming while a client's connection has too much unsent data buffered (256kb), resuming once it drains. Consumers that fall too far behind are disconnected with the existing `ConsumerTooSlow` close reason rather than being buffered indefinitely.

Close behavior is unchanged and now covered by tests: clients are still disconnected gracefully with `FutureCursor`, `OutdatedCursor`, or `ConsumerTooSlow` reasons as appropriate.